### PR TITLE
docs: add PEN internals deep-dive to docs/pen

### DIFF
--- a/docs/pen/00_pen-deepdive.md
+++ b/docs/pen/00_pen-deepdive.md
@@ -1,0 +1,165 @@
+---
+name: PEN Policy VM — Overview & Index
+description: Index cho PEN deep-dive — tổng quan kiến trúc và links đến từng lớp chi tiết
+type: project
+---
+# PEN Policy VM — Overview
+
+> **One-liner**: PEN = một bytecode VM nhỏ (Zig → WASM) nhúng thẳng vào soul ID, cho phép bất kỳ node nào trong graph tự mang theo "luật kiểm soát write" của riêng nó — không cần server, không cần auth service.
+
+---
+
+## Bức tranh tổng thể
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'fontSize': '15px', 'lineColor': '#CBD5E1', 'edgeLabelBackground': '#0F172A', 'edgeLabelColor': '#F8FAFC'}}}%%
+graph TB
+    DEV(["🧑‍💻 Developer\nZEN.pen(spec)\n→ soul string"])
+
+    subgraph COMPILE["① COMPILE — DSL → Bytecode"]
+        direction LR
+        DSL["High-level Spec\n{key, val, sign, pow...}"]
+        COMP["pen.js Compiler\nAST → opcodes"]
+        BC["Bytecode\n[ver][expr_tree][policy_tail]"]
+        B62["Base62 Pack\n→ '!' + base62_str"]
+        DSL --> COMP --> BC --> B62
+    end
+
+    subgraph SOUL["② SOUL — Identity baked-in"]
+        direction LR
+        SOULID["Soul ID\n'!abc123/path'"]
+        PENCODE["Pencode segment\nbytecode encoded"]
+        PATH["Path segment\nafter '/'"]
+        SOULID --> PENCODE & PATH
+    end
+
+    subgraph WRITE["③ WRITE PATH — Every write validated"]
+        direction TB
+        PUT["zen.put(val)"]
+        DECODE["Decode soul\nbase62 → bytes"]
+        SCAN["scanpolicy()\nextract tail bytes"]
+        PRECHECK["Pre-check\nPoW mining / signer"]
+        VMRUN["pen.run(bytecode, regs)\nWASM execution"]
+        APPLY["applypolicy()\nSGN / CRT / NOA"]
+        STORE["HAM → Storage → Mesh"]
+        REJECT["❌ Reject"]
+        PUT --> DECODE --> SCAN --> PRECHECK --> VMRUN
+        VMRUN --> TRUE_LBL["✓ true"]
+        VMRUN --> FALSE_LBL["✗ false"]
+        TRUE_LBL --> APPLY --> STORE
+        FALSE_LBL --> REJECT
+    end
+
+    subgraph VM["④ VM INTERNALS — Zig/WASM"]
+        direction LR
+        REG["8 Registers\nR0=key R1=val\nR2=soul R3=state\nR4=now R5=writer\nR6=path R7=nonce"]
+        ISA["ISA\n~40 opcodes\nLiterals/Compare\nArith/String/Control"]
+        EXEC["Eval loop\nrecursive tree walk\nshort-circuit AND/OR"]
+        REG --- ISA --- EXEC
+    end
+
+    DEV --> COMPILE --> SOUL
+    SOUL --> WRITE
+    VM --> RUNS_LBL["⚙ runs inside"]
+    RUNS_LBL -.-> VMRUN
+
+    style DEV fill:#0F172A,stroke:#475569,stroke-width:1.5px,color:#F8FAFC
+
+    style COMPILE fill:#1D4ED8,stroke:#93C5FD,stroke-width:1.5px,color:#EFF6FF
+    style DSL fill:#1E40AF,stroke:#93C5FD,stroke-width:1px,color:#DBEAFE
+    style COMP fill:#1E40AF,stroke:#93C5FD,stroke-width:1px,color:#DBEAFE
+    style BC fill:#1E40AF,stroke:#93C5FD,stroke-width:1px,color:#DBEAFE
+    style B62 fill:#1E40AF,stroke:#93C5FD,stroke-width:1px,color:#DBEAFE
+
+    style SOUL fill:#6D28D9,stroke:#C4B5FD,stroke-width:1.5px,color:#F5F3FF
+    style SOULID fill:#5B21B6,stroke:#C4B5FD,stroke-width:1px,color:#EDE9FE
+    style PENCODE fill:#5B21B6,stroke:#C4B5FD,stroke-width:1px,color:#EDE9FE
+    style PATH fill:#5B21B6,stroke:#C4B5FD,stroke-width:1px,color:#EDE9FE
+
+    style WRITE fill:#15803D,stroke:#86EFAC,stroke-width:1.5px,color:#F0FDF4
+    style PUT fill:#166534,stroke:#86EFAC,stroke-width:1px,color:#DCFCE7
+    style DECODE fill:#166534,stroke:#86EFAC,stroke-width:1px,color:#DCFCE7
+    style SCAN fill:#166534,stroke:#86EFAC,stroke-width:1px,color:#DCFCE7
+    style PRECHECK fill:#166534,stroke:#86EFAC,stroke-width:1px,color:#DCFCE7
+    style VMRUN fill:#14532D,stroke:#4ADE80,stroke-width:2px,color:#DCFCE7
+    style APPLY fill:#166534,stroke:#86EFAC,stroke-width:1px,color:#DCFCE7
+    style STORE fill:#166534,stroke:#86EFAC,stroke-width:1px,color:#DCFCE7
+    style REJECT fill:#7F1D1D,stroke:#FCA5A5,stroke-width:1.5px,color:#FEE2E2
+    style TRUE_LBL fill:#14532D,stroke:#4ADE80,stroke-width:1.5px,color:#4ADE80
+    style FALSE_LBL fill:#7F1D1D,stroke:#FCA5A5,stroke-width:1.5px,color:#FCA5A5
+    style RUNS_LBL fill:#92400E,stroke:#FCD34D,stroke-width:1.5px,color:#FCD34D
+
+    style VM fill:#B45309,stroke:#FCD34D,stroke-width:1.5px,color:#FFFBEB
+    style REG fill:#92400E,stroke:#FCD34D,stroke-width:1px,color:#FEF3C7
+    style ISA fill:#92400E,stroke:#FCD34D,stroke-width:1px,color:#FEF3C7
+    style EXEC fill:#92400E,stroke:#FCD34D,stroke-width:1px,color:#FEF3C7
+```
+
+---
+
+## Index — 8 lớp chi tiết
+
+| #   | Lớp                  | Nội dung                                                                                    | File                                         |
+| --- | -------------------- | ------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| 1   | **Soul Encoding**    | Bytecode sống trong ID — format `!base62/path`, base62, policy tail, immutability           | [01_soul-encoding.md](01_soul-encoding.md)   |
+| 2   | **ISA**              | ~40 opcodes chia 8 nhóm: Literals, Control, Compare, Arith, String, Type, Macros, Shortcuts | [02_isa.md](02_isa.md)                       |
+| 3   | **Registers**        | 8 inputs cố định (key, val, soul, state, now, writer, path, nonce) + 4 LET locals           | [03_registers.md](03_registers.md)           |
+| 4   | **Write Pipeline**   | 7 bước từ `zen.put()` đến storage: decode → scanpolicy → PoW mine → VM → PoW verify → auth  | [04_write-pipeline.md](04_write-pipeline.md) |
+| 5   | **Policy Tail**      | 4 chế độ auth: SGN (ECDSA), CRT (certificate), NOA (open), PoW                              | [05_policy-tail.md](05_policy-tail.md)       |
+| 6   | **PoW**              | Canonical block, SHA-256 mining, anti-replay binding, difficulty config                     | [06_pow.md](06_pow.md)                       |
+| 7   | **Compiler DSL**     | `ZEN.pen(spec)` — viết policy bằng JS thay vì bytecode tay, ví dụ thực tế                   | [07_compiler-dsl.md](07_compiler-dsl.md)     |
+| 8   | **ZACP Integration** | Protocol dùng PEN: inboxSoul, chanSoul, dmSoul, candle key                                  | [08_zacp.md](08_zacp.md)                     |
+
+---
+
+## Mental Model tổng kết
+
+```
+PEN = Bytecode VM nhỏ nhất có thể
+    + Được pack vào soul ID (không thể thay đổi)
+    + Chạy mỗi lần có write đến soul đó
+    + Nhận 8 registers về write context
+    + Return true/false
+    + Kết hợp với policy tail (sign/cert/open/pow)
+    + Không có side effects, không có network calls
+    + Mọi peer đều verify được độc lập
+```
+
+**Cách nhớ 4 layer của PEN:**
+
+1. **Soul** = bytecode encoded as ID (immutable contract) → [Lớp 1](01_soul-encoding.md)
+2. **Predicate** = VM eval — "data này có hợp lệ không?" → [Lớp 2](02_isa.md) + [Lớp 3](03_registers.md)
+3. **Policy** = auth mode — "người này có quyền không?" → [Lớp 5](05_policy-tail.md)
+4. **PoW** = anti-spam — "người này có bỏ công sức không?" → [Lớp 6](06_pow.md)
+
+Tất cả 4 layer đều được enforce **tại mọi peer**, **không cần server**, **không cần out-of-band communication**.
+
+---
+
+## Điểm mạnh
+
+| #   | Điểm mạnh                  | Chi tiết                                                          |
+| --- | -------------------------- | ----------------------------------------------------------------- |
+| 1   | **Serverless enforcement** | Mọi peer đều verify được — không cần trust server                 |
+| 2   | **Policy immutable**       | Bytecode baked vào soul ID, không thể thay đổi sau khi tạo        |
+| 3   | **Composable**             | AND/OR/NOT → ghép policy phức tạp tùy ý                           |
+| 4   | **Canonical PoW binding**  | Nonce bind (soul+key+val+state) → replay attack blocked           |
+| 5   | **Deterministic VM**       | Không có side effects, không có callbacks vào JS, pure evaluation |
+| 6   | **Short-circuit eval**     | AND/OR dừng sớm → hiệu quả với predicate lớn                      |
+| 7   | **Time-window candle**     | Tự nhiên chống replay key cũ trong messaging                      |
+| 8   | **Compact encoding**       | Base62 → URL-safe, dùng được làm path segment                     |
+
+---
+
+## Điểm yếu
+
+| #   | Điểm yếu                      | Tác động                                                                               |
+| --- | ----------------------------- | -------------------------------------------------------------------------------------- |
+| 1   | **WASM dependency**           | Nếu browser không load WASM → toàn bộ PEN fail. Vi phạm "1 JS file" promise            |
+| 2   | **String max 128 bytes**      | Value type trong VM capped ở 128 bytes — không validate được long string content       |
+| 3   | **Opaque bytecode**           | Khi write bị reject, developer không biết tại sao (predicate nào fail?)                |
+| 4   | **No dynamic state**          | Predicate không đọc được data khác trong graph — không thể "kiểm tra membership table" |
+| 5   | **Policy frozen at creation** | Soul ID cố định → muốn thay đổi policy phải tạo soul mới, migrate data                 |
+| 6   | **PoW difficulty fixed**      | Không thể adaptive difficulty — spam tăng → phải tạo soul mới với difficulty cao hơn   |
+| 7   | **REGEX stub**                | Opcode 0x59 REGEX tồn tại trong ISA nhưng luôn return false trong core                 |
+| 8   | **Low discoverability**       | Soul ID chứa bytecode opaque → khó debug, khó inspect bằng mắt                         |

--- a/docs/pen/01_soul-encoding.md
+++ b/docs/pen/01_soul-encoding.md
@@ -1,0 +1,138 @@
+---
+name: PEN — Lớp 1: Soul Encoding
+description: Bytecode sống trong Soul ID — format, base62, policy tail, tại sao thiết kế vậy
+type: project
+---
+
+# Lớp 1 — Soul Encoding: Bytecode sống trong ID
+
+> **Ý tưởng cốt lõi**: Thay vì lưu "luật ghi dữ liệu" ở một server riêng, PEN *nhúng trực tiếp luật đó vào tên của node*. Ai cũng có thể đọc luật chỉ bằng cách nhìn vào soul ID — không cần hỏi ai.
+
+---
+
+## Soul là gì?
+
+Soul là **chuỗi định danh duy nhất** cho mỗi node trong Zen graph — tương tự như URL của một tài nguyên. Mỗi node có đúng một soul, và soul đó không bao giờ thay đổi.
+
+Với PEN soul, định danh đó *chứa luôn bytecode* của policy:
+
+```
+"!" + base62(bytecode) + "/" + path_segment
+ │         │                       │
+ │         └── predicate + policy  └── R[6] register value
+ └── prefix = "đây là PEN soul"
+```
+
+**Ví dụ thực tế:**
+```
+!xK9mP2qR8.../usr/alice
+│           │   │
+│           │   └── path: "usr/alice" → nạp vào R[6]
+│           └── dấu phân tách
+└── "!" + chuỗi base62 chứa toàn bộ bytecode
+```
+
+---
+
+## Cấu trúc bên trong Bytecode
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'fontSize': '14px'}}}%%
+graph LR
+    SOUL["Soul: '!xK9mP2.../usr/alice'"]
+
+    SOUL --> P1["'!'  prefix\nMark as PEN soul"]
+    SOUL --> P2["'xK9mP2...'\nbase62(bytecode)"]
+    SOUL --> P3["'/usr/alice'\npath → R[6]"]
+
+    P2 --> BC["Bytecode layout:\n[0x01 version]\n[expression tree]\n[0xC0/C1/C3/C4 policy tail]"]
+
+    BC --> EX["Expression tree\nVM thực thi phần này\ntrả về true/false"]
+    BC --> POL["Policy tail\nCHỈ pen.js đọc\nVM không thấy"]
+
+    POL --> S0["0xC0 SGN\nSign required"]
+    POL --> S1["0xC1 CRT + pubkey\nCertificate required"]
+    POL --> S2["0xC3 NOA\nOpen (no auth)"]
+    POL --> S3["0xC4 PoW config\nProof-of-Work"]
+
+    style SOUL fill:#1E293B,color:#fff
+    style BC fill:#7C3AED,color:#fff
+    style POL fill:#D97706,color:#fff
+    style S0 fill:#DCFCE7,stroke:#22C55E,color:#14532D
+    style S1 fill:#FEF3C7,stroke:#F59E0B,color:#78350F
+    style S2 fill:#DBEAFE,stroke:#3B82F6,color:#1E3A5F
+    style S3 fill:#FEE2E2,stroke:#EF4444,color:#7F1D1D
+    linkStyle 0 stroke:#94A3B8,stroke-width:2px
+    linkStyle 1 stroke:#94A3B8,stroke-width:2px
+    linkStyle 2 stroke:#94A3B8,stroke-width:2px
+    linkStyle 3 stroke:#A78BFA,stroke-width:2px
+    linkStyle 4 stroke:#A78BFA,stroke-width:2px
+    linkStyle 5 stroke:#F59E0B,stroke-width:2px
+    linkStyle 6 stroke:#22C55E,stroke-width:2px
+    linkStyle 7 stroke:#F59E0B,stroke-width:2px
+    linkStyle 8 stroke:#3B82F6,stroke-width:2px
+    linkStyle 9 stroke:#EF4444,stroke-width:2px
+```
+
+Bytecode có 3 phần:
+
+| Phần | Nội dung | Ai dùng |
+|------|----------|---------|
+| `[0x01]` | Version byte | Tất cả |
+| Expression tree | Opcodes kiểm tra key/val/path/... | VM (Zig/WASM) thực thi |
+| Policy tail | 1 byte chỉ định auth mode (+ optional pubkey) | `pen.js` đọc trước khi gọi VM |
+
+> **Tại sao tách biệt?** VM chỉ cần biết "data có hợp lệ không?" (true/false). Việc "người này có quyền không?" là câu hỏi khác — được xử lý bởi policy tail *sau khi* VM pass.
+
+---
+
+## Tại sao Base62?
+
+Bytecode là binary (bytes 0x00–0xFF). Không thể dùng trực tiếp trong URL hay path.
+
+**Base62** dùng bộ ký tự `[0-9A-Za-z]` — 62 ký tự:
+- URL-safe: không có `+`, `/`, `=` cần encode
+- Dùng được trong path segment (sau dấu `/`)
+- Human-readable hơn base64 một chút
+- Mật độ cao hơn hex (hex cần 2 ký tự/byte, base62 ≈ 1.34 ký tự/byte)
+
+---
+
+## Policy Tail — 4 chế độ xác thực
+
+Byte cuối cùng của bytecode quyết định **ai được phép ghi**:
+
+| Opcode | Tên | Ý nghĩa | Dùng khi |
+|--------|-----|---------|---------|
+| `0xC0` | SGN | Writer phải ký bằng private key | Profile cá nhân, owned data |
+| `0xC1` | CRT + pubkey | Writer phải có certificate từ owner | Channel thành viên, invite-only |
+| `0xC3` | NOA / OPEN | Không cần auth — ai cũng ghi được | Public data, collaborative spaces |
+| `0xC4` | PoW config | Writer phải mine proof-of-work | Anti-spam inbox, rate limiting |
+
+> SGN và CRT là về **danh tính** (ai?). PoW là về **nỗ lực** (có bỏ công sức không?). NOA là không hỏi gì cả.
+
+---
+
+## Immutability — Điều quan trọng nhất
+
+Vì bytecode được **baked vào soul ID**, soul ID là **bất biến**:
+
+```
+Soul ID thay đổi  ⟺  Bytecode thay đổi  ⟺  Đây là soul khác hoàn toàn
+```
+
+Điều này có nghĩa là:
+- Không thể "upgrade" policy của một soul đang tồn tại
+- Nếu muốn thay đổi luật → phải tạo soul mới + migrate data
+- Mọi peer cũ vẫn enforce đúng policy cũ nếu họ có soul ID cũ
+
+Đây là **thiết kế có chủ ý**: policy phải predictable và tamper-proof.
+
+---
+
+## Xem thêm
+
+- [Lớp 2 — ISA: Tập lệnh VM](02_isa.md) — các opcodes bên trong expression tree
+- [Lớp 3 — Registers](03_registers.md) — 8 registers được nạp vào mỗi lần validate
+- [Lớp 4 — Write Pipeline](04_write-pipeline.md) — luồng từ `zen.put()` đến storage
+- [Lớp 5 — Policy Tail](05_policy-tail.md) — 4 chế độ auth chi tiết hơn

--- a/docs/pen/02_isa.md
+++ b/docs/pen/02_isa.md
@@ -1,0 +1,301 @@
+---
+name: PEN — Lớp 2: ISA (Instruction Set Architecture)
+description: ~40 opcodes chia 8 nhóm — Literals, Control, Compare, Arith, String, Type, Macros, Shortcuts
+type: project
+---
+
+# Lớp 2 — ISA: Tập lệnh của VM
+
+> **Ý tưởng cốt lõi**: VM của PEN chỉ cần trả lời một câu hỏi — *"Write này có hợp lệ không?"* Vì vậy ISA được thiết kế tối giản: không có I/O, không có memory allocation, không có loops — chỉ có evaluation thuần túy.
+
+---
+
+## Tổng quan 8 nhóm opcode
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'fontSize': '13px', 'primaryColor': '#0F172A', 'primaryTextColor': '#F8FAFC', 'primaryBorderColor': '#475569', 'lineColor': '#94A3B8', 'background': '#0F172A', 'nodeBorder': '#475569', 'clusterBkg': '#1E293B', 'titleColor': '#F8FAFC', 'edgeLabelBackground': '#1E293B'}}}%%
+graph LR
+    ISA{{"ISA — ~40 Opcodes"}}
+
+    subgraph LEFT[ ]
+        direction TB
+        LIT["📦 Literals
+
+0x00 NULL
+0x01 TRUE / 0x02 FALSE
+0x03 STR len utf8
+0x04 UINT  ULEB128
+0x07 INT  SLEB128
+0x08 F64  big-endian
+0x10 REG n"]
+
+        CTRL["🔀 Control
+
+0x20 AND n  short-circuit
+0x21 OR n  short-circuit
+0x22 NOT
+0x23 PASS  always true
+0x24 FAIL  always false
+0x70 LET slot def body
+0x71 IF cond then else"]
+
+        CMP["⚖️ Compare
+
+0x30 EQ / 0x31 NE
+0x32 LT / 0x33 GT
+0x34 LTE / 0x35 GTE"]
+
+        ARITH["🔢 Arithmetic
+
+0x40 ADD / 0x41 SUB
+0x42 MUL / 0x43 DIVU
+0x44 MOD / 0x45 DIVF
+0x46 ABS / 0x47 NEG"]
+    end
+
+    subgraph RIGHT[ ]
+        direction TB
+        STR["🔤 String
+
+0x50 LEN
+0x51 SLICE str s e
+0x52 SEG str sep idx
+0x53 TONUM / 0x54 TOSTR
+0x55 CONCAT
+0x56 PRE / 0x57 SUF
+0x58 INCLUDES
+0x5A UPPER / 0x5B LOWER"]
+
+        TYPE["🏷️ Type check
+
+0x60 ISS  is string?
+0x61 ISN  is number?
+0x62 ISX  is null?
+0x63 ISB  is bool?
+0x64 LNG min max"]
+
+        MACRO["⚡ Macros
+
+0x80 SEGR reg sep idx
+0x81 SEGRN → TONUM SEG"]
+
+        SHORT["🏃 Shortcuts
+
+0xE0-0xEF inline 0-15
+0xF0-0xF5 REG 0 - REG 5
+0xF8-0xFB local 0 - local 3"]
+    end
+
+    ISA --> LEFT
+    ISA --> RIGHT
+
+    style ISA fill:#1E293B,color:#F8FAFC,stroke:#64748B,stroke-width:2px
+    style LEFT fill:#0F172A,stroke:#334155,stroke-width:1px
+    style RIGHT fill:#0F172A,stroke:#334155,stroke-width:1px
+    style LIT fill:#1E3A5F,stroke:#3B82F6,color:#BFDBFE,stroke-width:2px
+    style CTRL fill:#14532D,stroke:#22C55E,color:#BBF7D0,stroke-width:2px
+    style CMP fill:#78350F,stroke:#F59E0B,color:#FEF3C7,stroke-width:2px
+    style ARITH fill:#7F1D1D,stroke:#EF4444,color:#FEE2E2,stroke-width:2px
+    style STR fill:#3B0764,stroke:#A855F7,color:#E9D5FF,stroke-width:2px
+    style TYPE fill:#064E3B,stroke:#10B981,color:#A7F3D0,stroke-width:2px
+    style MACRO fill:#7C2D12,stroke:#F97316,color:#FED7AA,stroke-width:2px
+    style SHORT fill:#0C4A6E,stroke:#0EA5E9,color:#BAE6FD,stroke-width:2px
+```
+
+---
+
+## Chi tiết từng nhóm
+
+### 📦 Literals — Đưa giá trị vào stack
+
+Literals là cách bytecode nhúng các hằng số vào trong instruction stream.
+
+| Opcode | Tên | Mô tả | Encoding |
+|--------|-----|-------|---------|
+| `0x00` | NULL | Giá trị null | 1 byte |
+| `0x01` | TRUE | Boolean true | 1 byte |
+| `0x02` | FALSE | Boolean false | 1 byte |
+| `0x03` | STR | String literal | `[0x03][len:u8][utf8 bytes]` |
+| `0x04` | UINT | Unsigned integer | ULEB128 (variable length) |
+| `0x07` | INT | Signed integer | SLEB128 (variable length) |
+| `0x08` | F64 | Float 64-bit | 8 bytes, big-endian |
+| `0x10` | REG(n) | Đọc register n | `[0x10][n:u8]` |
+
+> **ULEB128/SLEB128**: Encoding tiết kiệm space — số nhỏ (0–127) chỉ cần 1 byte, số lớn hơn dùng thêm byte. Phổ biến trong WASM và protobuf.
+
+**Ví dụ — đọc register R[2] rồi so sánh với string `"alice"`:**
+
+```text
+Bytecode (hex):  30  10 02  03 05 61 6C 69 63 65
+                 │   │  │   │  │  [a  l  i  c  e]
+                 │   │  │   │  └─ len = 5
+                 │   │  │   └──── 0x03 = STR opcode
+                 │   │  └──────── n = 2  → REG(2)
+                 │   └─────────── 0x10 = REG opcode
+                 └─────────────── 0x30 = EQ
+```
+Stack sau khi thực thi: `[true]` nếu R[2] == `"alice"`, `[false]` nếu không.
+
+---
+
+### 🔀 Control — Logic và luồng thực thi
+
+Đây là nhóm quan trọng nhất — quyết định cách kết hợp nhiều điều kiện:
+
+| Opcode | Tên | Mô tả |
+|--------|-----|-------|
+| `0x20` | AND(n) | Tất cả n sub-expr phải true. **Short-circuit**: dừng ngay khi gặp false đầu tiên |
+| `0x21` | OR(n) | Ít nhất 1 trong n sub-expr phải true. **Short-circuit**: dừng ngay khi gặp true đầu tiên |
+| `0x22` | NOT | Đảo ngược kết quả |
+| `0x23` | PASS | Luôn trả về true (no-op predicate) |
+| `0x24` | FAIL | Luôn trả về false (block all writes) |
+| `0x70` | LET | Bind một sub-expr vào local variable để dùng lại |
+| `0x71` | IF | Conditional: `if cond then expr1 else expr2` |
+
+**Ví dụ AND với short-circuit:**
+
+```text
+AND(3, [ISS(R1), LNG(R1, 1, 280), PRE(R0, "tweet_")])
+         ↓
+         Nếu R1 không phải string → dừng ngay, không check LNG hay PRE
+```
+
+---
+
+### ⚖️ Compare — So sánh giá trị
+
+| Opcode | Ý nghĩa |
+|--------|---------|
+| `0x30` EQ | Bằng nhau |
+| `0x31` NE | Khác nhau |
+| `0x32` LT | Nhỏ hơn |
+| `0x33` GT | Lớn hơn |
+| `0x34` LTE | Nhỏ hơn hoặc bằng |
+| `0x35` GTE | Lớn hơn hoặc bằng |
+
+**Ví dụ — chỉ cho phép ghi nếu R[5] (pubkey của writer) đúng là Alice:**
+
+```text
+EQ(R[5], "alice_pubkey")
+→ true nếu writer ký bằng đúng key của Alice, false với bất kỳ ai khác
+```
+
+---
+
+### 🔤 String — Xử lý chuỗi
+
+Nhóm opcode phong phú nhất vì key/val/path đều là string:
+
+| Opcode | Tên | Dùng để |
+|--------|-----|---------|
+| `0x50` LEN | Độ dài chuỗi | Kiểm tra length |
+| `0x51` SLICE | Cắt chuỗi `[s:e]` | Lấy substring |
+| `0x52` SEG | Tách theo separator, lấy index n | Parse structured keys như `"msg_1234"` |
+| `0x53` TONUM | Chuyển string → number | Parse timestamp từ key |
+| `0x54` TOSTR | Chuyển number → string | Format check |
+| `0x55` CONCAT | Nối 2 chuỗi | Build expected values |
+| `0x56` PRE | Kiểm tra prefix | Key phải bắt đầu bằng `"tweet_"` |
+| `0x57` SUF | Kiểm tra suffix | Key phải kết thúc bằng `".json"` |
+| `0x58` INCLUDES | Kiểm tra substring | Value chứa keyword nào đó |
+| `0x5A` UPPER | Uppercase | Normalize |
+| `0x5B` LOWER | Lowercase | Normalize |
+
+> ⚠️ **Giới hạn**: String trong VM capped ở **128 bytes**. Đủ cho key/path validation, nhưng không validate được long content.
+
+**Ví dụ — key phải có dạng `"msg_<id>"` và kết thúc bằng `".json"`:**
+
+```text
+SEG(R[0], "_", 0)   → lấy phần trước "_"  → phải là "msg"
+SEG(R[0], "_", 1)   → lấy phần sau "_"    → id (dùng TONUM nếu cần số)
+SUF(R[0], ".json")  → kiểm tra suffix      → true nếu kết thúc bằng ".json"
+```
+
+---
+
+### 🏷️ Type Check — Kiểm tra kiểu dữ liệu
+
+| Opcode | Kiểm tra |
+|--------|---------|
+| `0x60` ISS | Is String? |
+| `0x61` ISN | Is Number? |
+| `0x62` ISX | Is Null? |
+| `0x63` ISB | Is Boolean? |
+| `0x64` LNG | Length in range [min, max]? |
+
+**Ví dụ — `LNG` kết hợp check kiểu + check length trong 1 opcode, thay vì phải viết 3 điều kiện riêng:**
+
+```text
+LNG(R[1], 1, 280)
+
+tương đương với:
+  ISS(R[1])          → R[1] phải là string
+  LEN(R[1]) >= 1     → không được rỗng
+  LEN(R[1]) <= 280   → không quá 280 ký tự (giới hạn tweet)
+```
+
+---
+
+### ⚡ Macros — Shorthand cho pattern phổ biến
+
+| Opcode | Tên | Tương đương |
+|--------|-----|------------|
+| `0x80` SEGR | Segment Register | `SEG(REG(n), sep, idx)` |
+| `0x81` SEGRN | Segment Register to Number | `TONUM(SEG(REG(n), sep, idx))` |
+
+**Ví dụ — validate candle key dạng `"candle_1714000000"` (prefix + unix timestamp):**
+
+```text
+SEGRN(R[0], "_", 1)
+
+từng bước:
+  R[0]              = "candle_1714000000"   (key của node)
+  SEG(..., "_", 1)  = "1714000000"          (lấy phần sau "_")
+  TONUM(...)        = 1714000000            (parse thành số để so sánh range)
+```
+
+---
+
+### 🏃 Shortcuts — Encoding tiết kiệm
+
+Thay vì `[0x10][0x00]` (2 bytes) để đọc R[0], dùng shortcut `[0xF0]` (1 byte):
+
+| Range | Ý nghĩa |
+|-------|---------|
+| `0xE0`–`0xEF` | Inline integers 0–15 (thay cho UINT 0x04) |
+| `0xF0`–`0xF5` | REG(0)–REG(5) shortcuts |
+| `0xF8`–`0xFB` | local[0]–local[3] (LET variables) |
+
+**Ví dụ — cùng một điều kiện, viết dài vs shortcut:**
+
+```text
+Dài:      10 00  →  REG opcode + n=0  (2 bytes để đọc R[0])
+Shortcut: F0     →  REG(0) inline     (1 byte, tiết kiệm 50%)
+
+Dài:      04 07  →  UINT opcode + value=7  (2 bytes)
+Shortcut: E7     →  inline integer 7       (1 byte)
+```
+
+---
+
+## Bytecode trong thực tế — Ví dụ đọc tay
+
+Policy "key phải bắt đầu bằng `tweet_`, val là string 1–280 ký tự":
+
+```text
+Bytecode (hex):  20 02  F0 56 03 07 74 77 65 65 74 5F  F1 64 01 18
+                 │  │   │  │  │  │  [t w e e t _]     │  │  │  │
+                 │  │   │  │  │  └─ STR "tweet_"      │  │  │  └─ max 280 (0x118 = 280, ULEB)
+                 │  │   │  │  └──── 0x03 = STR opcode │  │  └──── min 1
+                 │  │   │  └─────── 0x56 = PRE         │  └─────── LNG opcode
+                 │  │   └────────── 0xF0 = R[0]        └────────── 0xF1 = R[1]
+                 │  └────────────── 2 sub-expressions
+                 └───────────────── 0x20 = AND
+```
+
+---
+
+## Xem thêm
+
+- [Lớp 1 — Soul Encoding](01_soul-encoding.md) — bytecode được pack vào soul ID như thế nào
+- [Lớp 3 — Registers](03_registers.md) — 8 inputs mà VM nhận mỗi lần chạy
+- [Lớp 7 — Compiler DSL](07_compiler-dsl.md) — viết policy bằng JS thay vì viết bytecode tay

--- a/docs/pen/03_registers.md
+++ b/docs/pen/03_registers.md
@@ -1,0 +1,186 @@
+---
+name: PEN — Lớp 3: Registers
+description: 8 registers cố định nạp vào VM mỗi lần validate — key, val, soul, state, now, writer, path, nonce
+type: project
+---
+
+# Lớp 3 — Registers: Input của mỗi lần validate
+
+> **Ý tưởng cốt lõi**: VM không có "database access" — nó chỉ nhìn thấy 8 giá trị về *write đang xảy ra*. Đây là toàn bộ context mà predicate có thể dùng để quyết định.
+
+---
+
+## 8 Registers cố định
+
+Mỗi khi `zen.put(val)` được gọi trên một PEN soul, VM nhận đúng 8 registers này:
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'fontSize': '13px', 'primaryColor': '#0F172A', 'primaryTextColor': '#F8FAFC', 'primaryBorderColor': '#475569', 'lineColor': '#94A3B8', 'background': '#0F172A', 'clusterBkg': '#1E293B', 'titleColor': '#F8FAFC', 'edgeLabelBackground': '#1E293B'}}}%%
+graph LR
+    subgraph LEFT["Write context → Registers"]
+        direction TB
+        R0["R[0] = key
+
+Key đang được ghi
+shortcut: 0xF0"]
+        R1["R[1] = val
+
+Value đang được ghi
+shortcut: 0xF1"]
+        R2["R[2] = soul
+
+Full soul string
+shortcut: 0xF2"]
+        R3["R[3] = state
+
+HAM timestamp
+shortcut: 0xF3"]
+    end
+
+    subgraph RIGHT[ ]
+        direction TB
+        R4["R[4] = now
+
+Date.now() ms
+shortcut: 0xF4"]
+        R5["R[5] = writer
+
+Writer's public key
+shortcut: 0xF5"]
+        R6["R[6] = path
+
+Path after pencode/"]
+        R7["R[7] = nonce
+
+PoW nonce  ctx.put '^' "]
+    end
+
+    subgraph LOCALS["LET locals — runtime bindings"]
+        direction TB
+        L0["R[128] = local[0]
+shortcut: 0xF8"]
+        L1["R[129] = local[1]
+shortcut: 0xF9"]
+        L2["R[130] = local[2]
+shortcut: 0xFA"]
+        L3["R[131] = local[3]
+shortcut: 0xFB"]
+    end
+
+    LEFT -. "LET opcode binds\nsub-expr result" .-> LOCALS
+    RIGHT -. "LET opcode binds\nsub-expr result" .-> LOCALS
+
+    style LEFT fill:#1E293B,stroke:#475569,color:#F8FAFC,stroke-width:1px
+    style RIGHT fill:#1E293B,stroke:#475569,color:#F8FAFC,stroke-width:1px
+    style LOCALS fill:#3B0764,stroke:#A855F7,color:#E9D5FF,stroke-width:2px
+    style R0 fill:#1E3A5F,stroke:#3B82F6,color:#BFDBFE,stroke-width:2px
+    style R1 fill:#1E3A5F,stroke:#3B82F6,color:#BFDBFE,stroke-width:2px
+    style R2 fill:#1E3A5F,stroke:#3B82F6,color:#BFDBFE,stroke-width:2px
+    style R3 fill:#1E3A5F,stroke:#3B82F6,color:#BFDBFE,stroke-width:2px
+    style R4 fill:#14532D,stroke:#22C55E,color:#BBF7D0,stroke-width:2px
+    style R5 fill:#14532D,stroke:#22C55E,color:#BBF7D0,stroke-width:2px
+    style R6 fill:#14532D,stroke:#22C55E,color:#BBF7D0,stroke-width:2px
+    style R7 fill:#14532D,stroke:#22C55E,color:#BBF7D0,stroke-width:2px
+    style L0 fill:#4C1D95,stroke:#A855F7,color:#E9D5FF,stroke-width:2px
+    style L1 fill:#4C1D95,stroke:#A855F7,color:#E9D5FF,stroke-width:2px
+    style L2 fill:#4C1D95,stroke:#A855F7,color:#E9D5FF,stroke-width:2px
+    style L3 fill:#4C1D95,stroke:#A855F7,color:#E9D5FF,stroke-width:2px
+```
+
+---
+
+## Ý nghĩa từng register
+
+| Register | Shortcut | Giá trị | Câu hỏi mà predicate có thể hỏi |
+|----------|---------|---------|--------------------------------|
+| R[0] | `0xF0` | Key đang được ghi | Key có đúng format không? Có prefix đúng không? |
+| R[1] | `0xF1` | Value đang được ghi | Value có đúng type không? Có trong giới hạn length không? |
+| R[2] | `0xF2` | Full soul string (`!...`) | Soul này có đúng như expected không? |
+| R[3] | `0xF3` | HAM state timestamp (float ms) | Write này có trong cửa sổ thời gian không? |
+| R[4] | `0xF4` | `Date.now()` tại thời điểm validate | Kiểm tra relative timing |
+| R[5] | `0xF5` | Public key của người đang ghi | Writer có phải Alice không? |
+| R[6] | — | Path segment (phần sau `/` trong soul) | Path có đúng không? |
+| R[7] | — | PoW nonce (từ `ctx.put['^']`) | Nonce có hợp lệ không? (dùng trong PoW verify) |
+
+---
+
+## Các câu hỏi phổ biến — mapping sang registers
+
+### "Chỉ Alice được ghi"
+```javascript
+EQ(R[5], alice_pubkey)   // R[5] = writer's public key
+```
+
+### "Key phải bắt đầu bằng 'msg_'"
+```javascript
+PRE(R[0], "msg_")        // R[0] = key being written
+```
+
+### "Value phải là string, 1–280 ký tự"
+```javascript
+AND(ISS(R[1]), LNG(R[1], 1, 280))   // R[1] = value
+```
+
+### "Chỉ ghi được trong cửa sổ thời gian (candle)"
+```javascript
+// Key = Math.floor(Date.now() / 300000)  ← candle index
+// R[0] = key, R[4] = now
+LTE(SEGRN(R[0], "_", 1), ADD(DIVU(R[4], 300000), 1))  // key <= now/300s + 1
+GTE(SEGRN(R[0], "_", 1), SUB(DIVU(R[4], 300000), 2))  // key >= now/300s - 2
+```
+
+---
+
+## LET locals — biến tạm trong VM
+
+4 registers từ R[128]–R[131] là **biến local** tạo ra bởi opcode `LET`. Cú pháp:
+
+```text
+LET(slot, def, body)
+      │     │     └── expression sử dụng local[slot]
+      │     └──────── expression tính ra giá trị, lưu vào local[slot]
+      └────────────── 0–3, tương ứng R[128]–R[131]
+```
+
+Mục đích: tính một sub-expression **một lần**, lưu vào local, dùng lại nhiều lần trong `body` — tránh tính lặp.
+
+**Ví dụ — candle window: chỉ ghi được nếu key nằm trong cửa sổ thời gian hiện tại ±2 slot:**
+
+```text
+LET(
+  slot = 0,
+  def  = DIVU(R[4], 300000),        ← tính candle index hiện tại: now / 300s
+                                        kết quả lưu vào local[0]
+  body = AND(
+    LTE(SEGRN(R[0], "_", 1), ADD(local[0], 1)),   ← key index <= now_slot + 1
+    GTE(SEGRN(R[0], "_", 1), SUB(local[0], 2))    ← key index >= now_slot - 2
+  )
+)
+```
+
+Nếu không có `LET`, `DIVU(R[4], 300000)` phải viết lại 2 lần trong `body`. Với `LET`, tính 1 lần → dùng `local[0]` cho cả hai nhánh.
+
+Không có side effects: `local[0]`–`local[3]` chỉ tồn tại trong scope của expression, không persist sau khi VM kết thúc.
+
+---
+
+## Điều VM KHÔNG thấy
+
+Đây là giới hạn quan trọng cần hiểu:
+
+| Thứ VM không thấy | Hệ quả |
+|-------------------|--------|
+| Data khác trong graph | Không thể kiểm tra "user có trong membership list không?" |
+| Lịch sử write trước | Không thể "chỉ cho phép update nếu đã có giá trị trước" |
+| Identity của peer relay | Không thể tin tưởng dựa trên nguồn gốc message |
+| Network state | Validate không cần external dependency — VM chạy hoàn toàn local |
+
+> Đây là trade-off có chủ ý: VM phải **deterministic và stateless** để mọi peer đều validate giống nhau mà không cần đồng bộ thêm data nào.
+
+---
+
+## Xem thêm
+
+- [Lớp 2 — ISA](02_isa.md) — các opcode dùng để đọc và xử lý registers
+- [Lớp 4 — Write Pipeline](04_write-pipeline.md) — registers được nạp vào VM tại bước nào
+- [Lớp 6 — PoW](06_pow.md) — R[7] nonce được dùng như thế nào

--- a/docs/pen/04_write-pipeline.md
+++ b/docs/pen/04_write-pipeline.md
@@ -1,0 +1,236 @@
+---
+name: PEN — Lớp 4: Write Validation Pipeline
+description: Luồng đầy đủ từ zen.put() đến storage — decode, scanpolicy, PoW mine, VM run, applypolicy
+type: project
+---
+
+# Lớp 4 — Write Validation Pipeline
+
+> **Ý tưởng cốt lõi**: Mỗi lần `zen.put()` được gọi trên PEN soul, write đó phải đi qua 7 bước kiểm tra. Tất cả xảy ra locally trên máy của người ghi — không có roundtrip server.
+
+---
+
+## Sơ đồ toàn bộ pipeline
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'fontSize': '13px', 'primaryColor': '#0F172A', 'primaryTextColor': '#F8FAFC', 'primaryBorderColor': '#475569', 'lineColor': '#94A3B8', 'background': '#0F172A', 'clusterBkg': '#1E293B', 'titleColor': '#F8FAFC', 'edgeLabelBackground': '#0F172A'}}}%%
+graph TB
+    subgraph TOP["① – ④  Chuẩn bị"]
+        direction LR
+        W(["zen.get(soul).put(val)"])
+        W --> CHK{"Soul\nbắt đầu '!'?"}
+        CHK -->|"Không"| PASS["Write thông thường\nBỏ qua PEN"]
+        CHK -->|"Có"| DEC
+
+        DEC["① Decode
+
+base62 → bytes
+Validate 2–512 bytes"]
+
+        DEC --> SCAN["② scanpolicy()
+
+Tree-skip qua expr
+→ sign / cert / open / pow"]
+
+        SCAN --> POW_CHK{"policy.pow\nchưa có nonce?"}
+        POW_CHK -->|"Có"| MINE["③ Auto-mine
+
+Build canonical block
+Tăng nonce → hash
+Đến khi prefix match"]
+        POW_CHK -->|"Không"| AUTH
+        MINE --> AUTH
+
+        AUTH["④ Writer
+
+sec.upub
+|| authenticator.pub"]
+    end
+
+    subgraph BOT["⑤ – ⑦  Thực thi & xác thực"]
+        direction LR
+        VMRUN["⑤ VM Execution
+
+pen.run(bytecode, regs)
+Zig WASM eval loop"]
+
+        VMRUN -->|"false"| FAIL1["❌ predicate failed"]
+        VMRUN -->|"true"| POWVFY{"policy.pow?"}
+
+        POWVFY -->|"Có"| HASHVFY["⑥ PoW Verify
+
+hash(block + ':' + nonce)
+Kiểm tra prefix"]
+        POWVFY -->|"Không"| APPLYPOL
+
+        HASHVFY -->|"Fail"| FAIL2["❌ PoW insufficient"]
+        HASHVFY -->|"Pass"| APPLYPOL
+
+        APPLYPOL["⑦ applypolicy()
+
+SGN: verify ECDSA
+CRT: verify certificate
+NOA: pass through"]
+
+        APPLYPOL -->|"OK"| NEXT["✅ HAM → Storage → Mesh"]
+        APPLYPOL -->|"Fail"| FAIL3["❌ cert invalid"]
+    end
+
+    AUTH --> VMRUN
+
+    style TOP fill:#0F172A,stroke:#334155,stroke-width:1px
+    style BOT fill:#0F172A,stroke:#334155,stroke-width:1px
+    style W fill:#1E293B,color:#F8FAFC,stroke:#64748B,stroke-width:2px
+    style CHK fill:#1E293B,color:#F8FAFC,stroke:#64748B,stroke-width:2px
+    style POW_CHK fill:#1E293B,color:#F8FAFC,stroke:#64748B,stroke-width:2px
+    style POWVFY fill:#1E293B,color:#F8FAFC,stroke:#64748B,stroke-width:2px
+    style PASS fill:#1E293B,color:#94A3B8,stroke:#475569,stroke-width:1px
+    style DEC fill:#1E3A5F,stroke:#3B82F6,color:#BFDBFE,stroke-width:2px
+    style SCAN fill:#1E3A5F,stroke:#3B82F6,color:#BFDBFE,stroke-width:2px
+    style MINE fill:#3B0764,stroke:#A855F7,color:#E9D5FF,stroke-width:2px
+    style AUTH fill:#1E3A5F,stroke:#3B82F6,color:#BFDBFE,stroke-width:2px
+    style VMRUN fill:#78350F,stroke:#F59E0B,color:#FEF3C7,stroke-width:2px
+    style HASHVFY fill:#1E3A5F,stroke:#3B82F6,color:#BFDBFE,stroke-width:2px
+    style APPLYPOL fill:#14532D,stroke:#22C55E,color:#BBF7D0,stroke-width:2px
+    style NEXT fill:#14532D,stroke:#22C55E,color:#BBF7D0,stroke-width:2px
+    style FAIL1 fill:#7F1D1D,stroke:#EF4444,color:#FEE2E2,stroke-width:2px
+    style FAIL2 fill:#7F1D1D,stroke:#EF4444,color:#FEE2E2,stroke-width:2px
+    style FAIL3 fill:#7F1D1D,stroke:#EF4444,color:#FEE2E2,stroke-width:2px
+```
+
+---
+
+## 7 bước chi tiết
+
+### ① Decode — Giải mã soul
+
+```javascript
+// pen.js (src/pen.js)
+var buf = pen.unpack(soul.slice(1, soul.indexOf('/')))
+// soul.slice(1) bỏ '!' prefix
+// indexOf('/') lấy phần pencode, bỏ path segment
+```
+
+- Base62 → raw bytes
+- Validate: length phải trong khoảng 2–512 bytes
+- Nếu invalid → throw ngay, không đi tiếp
+
+---
+
+### ② scanpolicy() — Đọc policy tail
+
+`scanpolicy()` cần tìm policy tail mà **không thực thi bytecode**. Nó dùng kỹ thuật "tree-skip":
+
+```
+Bytecode: [0x20][2][0xF0][0x56][0x03][6][t][w][e][e][t][_]  [0xF1][0x64][1][0x18]  [0xC0]
+                                                                                       ↑
+                                                                               Policy tail ở đây
+```
+
+Tree-skip đọc structure của mỗi opcode (biết nó có bao nhiêu children) để nhảy qua toàn bộ expression tree → đến byte cuối cùng = policy tail.
+
+Output: `{ sign: bool, cert: pubkey|null, open: bool, pow: config|null }`
+
+---
+
+### ③ Auto-mine PoW (nếu cần)
+
+Nếu policy là PoW và caller đã bật `opt.pow = true`:
+
+```javascript
+// Xây canonical block
+var block = JSON.stringify({ '#': soul, '.': key, ':': val, '>': state })
+var nonce = 0
+while (true) {
+  var hash = sha256(block + ':' + nonce)
+  if (hash.startsWith(unit.repeat(difficulty))) break
+  nonce++
+}
+ctx.put['^'] = nonce  // lưu nonce vào R[7]
+```
+
+Xem thêm tại [Lớp 6 — PoW](06_pow.md).
+
+---
+
+### ④ Xác định Writer
+
+```javascript
+var writer = sec.upub                  // User đang đăng nhập
+           || authenticator && authenticator.pub  // Hoặc auth service
+           || null
+```
+
+Writer's public key → nạp vào `R[5]` trước khi gọi VM.
+
+---
+
+### ⑤ VM Execution — Trái tim của PEN
+
+```javascript
+var result = pen.run(bytecode, {
+  0: key,     // R[0]
+  1: val,     // R[1]
+  2: soul,    // R[2]
+  3: state,   // R[3]
+  4: Date.now(), // R[4]
+  5: writer,  // R[5]
+  6: path,    // R[6]
+  7: nonce,   // R[7]
+})
+// result = true hoặc false
+```
+
+`pen.run()` gọi vào WASM compiled từ `src/pen.zig`. VM thực thi expression tree, trả về boolean.
+
+**Nếu false** → reject ngay, lỗi `"PEN: predicate failed"`.
+
+---
+
+### ⑥ PoW Verify (nếu policy là PoW)
+
+Dù đã mine ở bước ③, peer *nhận* write sẽ verify lại:
+
+```javascript
+var block = JSON.stringify({ '#': soul, '.': key, ':': val, '>': state })
+var hash = sha256(block + ':' + nonce)
+if (!hash.startsWith(unit.repeat(difficulty))) {
+  throw 'PEN: PoW insufficient'
+}
+```
+
+Peer tự compute lại hash từ data — không cần trust sender đã mine đúng.
+
+---
+
+### ⑦ applypolicy() — Kiểm tra auth
+
+| Policy | Hành động |
+|--------|----------|
+| NOA (0xC3) | Pass through — không làm gì |
+| SGN (0xC0) | Verify ECDSA signature. Writer phải đã ký data bằng private key |
+| CRT (0xC1) | Verify certificate từ owner. Writer phải có cert được owner cấp |
+
+Nếu pass → data được chuyển tiếp vào HAM → Storage → Mesh.
+
+---
+
+## Tại sao thứ tự này?
+
+```
+Decode → scanpolicy → [PoW mine] → writer ID → VM → [PoW verify] → auth
+```
+
+- **scanpolicy trước VM**: Cần biết policy để chuẩn bị (mine PoW, lấy writer ID)
+- **VM trước auth**: Predicate check rẻ hơn crypto verify — fail fast
+- **PoW verify sau VM**: Tránh tốn CPU hash nếu predicate đã fail
+- **applypolicy cuối**: Crypto verify tốn kém nhất — để cuối cùng
+
+---
+
+## Xem thêm
+
+- [Lớp 1 — Soul Encoding](01_soul-encoding.md) — bytecode được decode từ đâu
+- [Lớp 3 — Registers](03_registers.md) — 8 inputs nạp vào VM ở bước ⑤
+- [Lớp 5 — Policy Tail](05_policy-tail.md) — 4 chế độ auth ở bước ⑦
+- [Lớp 6 — PoW](06_pow.md) — chi tiết bước ③ và ⑥

--- a/docs/pen/05_policy-tail.md
+++ b/docs/pen/05_policy-tail.md
@@ -1,0 +1,218 @@
+---
+name: PEN — Lớp 5: Policy Tail
+description: 4 chế độ xác thực — SGN (ECDSA), CRT (certificate), NOA (open), PoW (proof-of-work)
+type: project
+---
+
+# Lớp 5 — Policy Tail: 4 chế độ xác thực
+
+> **Ý tưởng cốt lõi**: Predicate (VM) trả lời "data hợp lệ không?". Policy tail trả lời câu hỏi khác: "người này có *quyền* ghi không?" Hai câu hỏi độc lập, cả hai đều phải pass.
+
+---
+
+## Tổng quan 4 chế độ
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'fontSize': '14px'}}}%%
+graph TD
+    TAIL{{"Policy Tail\n(byte cuối trong bytecode)"}}
+
+    TAIL --> NOA["0xC3 — OPEN / NOA\nKhông cần auth\nAi cũng ghi được"]
+    TAIL --> SGN["0xC0 — SGN\nCần ECDSA signature\nWriter có private key"]
+    TAIL --> CRT["0xC1 — CRT + pubkey\nCần certificate\nTừ holder của pubkey đó"]
+    TAIL --> POW["0xC4 — PoW\nCần proof-of-work\nWriter phải mine"]
+
+    NOA --> EX1["Dùng cho:\n• Public chat\n• OpenStreetMap-style edits\n• Shared whiteboards"]
+    SGN --> EX2["Dùng cho:\n• Profile cá nhân\n• DM outbox\n• Owned namespace"]
+    CRT --> EX3["Dùng cho:\n• Channel membership\n• Invite-only projects\n• Access-controlled spaces"]
+    POW --> EX4["Dùng cho:\n• Inbox anti-spam\n• Rate limiting\n• Sybil resistance"]
+
+    style TAIL fill:#1E293B,color:#fff
+    style NOA fill:#DBEAFE,stroke:#3B82F6,color:#1E3A5F
+    style SGN fill:#DCFCE7,stroke:#22C55E,color:#14532D
+    style CRT fill:#FEF3C7,stroke:#F59E0B,color:#78350F
+    style POW fill:#FEE2E2,stroke:#EF4444,color:#7F1D1D
+    linkStyle 0 stroke:#3B82F6,stroke-width:2px
+    linkStyle 1 stroke:#22C55E,stroke-width:2px
+    linkStyle 2 stroke:#F59E0B,stroke-width:2px
+    linkStyle 3 stroke:#EF4444,stroke-width:2px
+    linkStyle 4 stroke:#3B82F6,stroke-width:2px
+    linkStyle 5 stroke:#22C55E,stroke-width:2px
+    linkStyle 6 stroke:#F59E0B,stroke-width:2px
+    linkStyle 7 stroke:#EF4444,stroke-width:2px
+```
+
+---
+
+## NOA — Open (0xC3): Ai cũng ghi được
+
+Không có auth. VM predicate pass → data được accept.
+
+**Khi nào dùng:**
+- Data public mà cộng đồng cùng contribute
+- Proof-of-concept và prototyping
+- Hệ thống đã có giới hạn khác (ví dụ: predicate check key format nghiêm ngặt)
+
+**Rủi ro:** Ai cũng ghi được, kể cả bot spam. Cần kết hợp với predicate chặt hoặc thêm PoW nếu cần rate-limit.
+
+---
+
+## SGN — Sign (0xC0): ECDSA signature
+
+Writer phải có private key tương ứng với public key được kỳ vọng.
+
+### Cách hoạt động
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'fontSize': '14px'}}}%%
+graph LR
+    A["Alice (writer)"]
+    SIGN["① Ký data bằng private key\nsig = ECDSA.sign(data, priv)"]
+    PUT["PUT { val, sig, soul, key }"]
+    VM["② VM check predicate\nkey/val format"]
+    VERIFY["③ ECDSA.verify(data, sig, pub)\nRecover pubkey từ sig"]
+    CHECK["④ Verify pubkey == R[5]\npubkey trong path/soul"]
+    OK["✅ Accept"]
+    FAIL["❌ Reject"]
+
+    A --> SIGN
+    SIGN --> PUT
+    PUT --> VM
+    VM --> VERIFY
+    VERIFY --> CHECK
+    CHECK --> OK
+    CHECK --> FAIL
+
+    style A fill:#DCFCE7,stroke:#22C55E,color:#14532D
+    style SIGN fill:#F0FDF4,stroke:#86EFAC,color:#14532D
+    style PUT fill:#1E293B,color:#94A3B8
+    style VM fill:#FEF3C7,stroke:#F59E0B,color:#78350F
+    style VERIFY fill:#FEF3C7,stroke:#F59E0B,color:#78350F
+    style CHECK fill:#FEF3C7,stroke:#F59E0B,color:#78350F
+    style OK fill:#DCFCE7,stroke:#22C55E,color:#14532D
+    style FAIL fill:#FEE2E2,stroke:#EF4444,color:#7F1D1D
+    linkStyle 0 stroke:#22C55E,stroke-width:2px
+    linkStyle 1 stroke:#94A3B8,stroke-width:2px
+    linkStyle 2 stroke:#94A3B8,stroke-width:2px
+    linkStyle 3 stroke:#F59E0B,stroke-width:2px
+    linkStyle 4 stroke:#F59E0B,stroke-width:2px
+    linkStyle 5 stroke:#22C55E,stroke-width:2px
+    linkStyle 6 stroke:#EF4444,stroke-width:2px
+```
+
+**Signature format** (86 chars base62 + recovery bit):
+```
+"~alice_pubkey/profile"  ← owned soul (tương tự)
+value được signed: ZEN.sign(val, pair) → "<86chars>0:original_val"
+                                               ↑ recovery bit (0 hoặc 1)
+```
+
+**Khi nào dùng:**
+- Profile của người dùng: `path = alice_pubkey` + `sign: true` → chỉ Alice mới ghi được
+- DM outbox: Tin nhắn gửi đi phải có chữ ký của người gửi
+
+---
+
+## CRT — Certificate (0xC1): Được cấp quyền bởi owner
+
+Writer không cần tự chứng minh — cần có "giấy phép" từ một authority cụ thể.
+
+### Cách hoạt động
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'fontSize': '14px'}}}%%
+graph LR
+    O["Owner (admin)"]
+    CERT["① Cấp certificate\ncert = sign(bob_pub, owner_priv)"]
+    B["Bob (member)"]
+    PUT["PUT { val, cert, soul }"]
+    VM["② VM predicate check"]
+    VERIFY["③ ECDSA.verify(bob_pub, cert, owner_pub)"]
+    CHECK["④ owner_pub match\npubkey trong CRT tail"]
+    OK["✅ Bob accepted as member"]
+
+    O --> CERT
+    CERT --> B
+    B --> PUT
+    PUT --> VM
+    VM --> VERIFY
+    VERIFY --> CHECK
+    CHECK --> OK
+
+    style O fill:#FEF3C7,stroke:#F59E0B,color:#78350F
+    style CERT fill:#FFFBEB,stroke:#FCD34D,color:#78350F
+    style B fill:#DBEAFE,stroke:#3B82F6,color:#1E3A5F
+    style PUT fill:#1E293B,color:#94A3B8
+    style VM fill:#FEF3C7,stroke:#F59E0B,color:#78350F
+    style VERIFY fill:#FEF3C7,stroke:#F59E0B,color:#78350F
+    style CHECK fill:#FEF3C7,stroke:#F59E0B,color:#78350F
+    style OK fill:#DCFCE7,stroke:#22C55E,color:#14532D
+    linkStyle 0 stroke:#F59E0B,stroke-width:2px
+    linkStyle 1 stroke:#F59E0B,stroke-width:2px
+    linkStyle 2 stroke:#3B82F6,stroke-width:2px
+    linkStyle 3 stroke:#94A3B8,stroke-width:2px
+    linkStyle 4 stroke:#F59E0B,stroke-width:2px
+    linkStyle 5 stroke:#F59E0B,stroke-width:2px
+    linkStyle 6 stroke:#22C55E,stroke-width:2px
+```
+
+**Encoding của CRT tail:**
+```
+[0xC1][pubkey_length:u8][pubkey_bytes...]
+        owner's public key embedded directly in soul bytecode
+```
+
+**Khi nào dùng:**
+- Channel với invite-only: Admin cấp cert cho từng member
+- Collaborative project: Owner mời contributor
+- Khác SGN ở chỗ: nhiều người có thể được cấp quyền (cert từ cùng 1 owner), thay vì chỉ 1 người cố định
+
+---
+
+## PoW — Proof-of-Work (0xC4): Phải bỏ công sức
+
+Writer phải giải một bài toán tính toán trước khi write được accept.
+
+**Encoding:**
+```
+[0xC4][field=7][difficulty:u8][unitlen:u8][unit bytes...]
+                     ↑               ↑           ↑
+               số lần lặp      độ dài 1 unit   ký tự unit
+```
+
+**Ví dụ:** `difficulty=2, unit="0"` → hash phải bắt đầu bằng `"00"`.
+
+Chi tiết về cơ chế mining và anti-replay xem tại [Lớp 6 — PoW](06_pow.md).
+
+**Khi nào dùng:**
+- Inbox anti-spam: Người gửi phải mine PoW → spam bot tốn CPU
+- Rate limiting tự nhiên: Mining mất thời gian → không thể flood
+- Sybil resistance: Tạo 1000 account gửi tin → cần mine 1000 lần
+
+**Kết hợp phổ biến:**
+```javascript
+// DM soul: phải ký (danh tính) + phải mine (chống spam)
+dmSoul(recipient) → { sign: true, pow: { unit: '0', difficulty: 1 } }
+```
+
+---
+
+## So sánh 4 chế độ
+
+| | NOA | SGN | CRT | PoW |
+|--|-----|-----|-----|-----|
+| **Ai được ghi** | Tất cả | Chỉ key holder | Ai có cert từ owner | Ai mine đủ |
+| **Cần gì** | Không | Private key | Certificate từ owner | CPU time |
+| **Verify bằng** | Không | ECDSA | ECDSA (cert) | SHA-256 hash |
+| **Revoke được không** | — | Không (đổi soul) | Không (đổi soul) | Không |
+| **Kết hợp được với PoW** | ✅ | ✅ | ✅ | — |
+
+> **Lưu ý quan trọng**: Policy tail là **bất biến** — baked vào soul ID. Muốn thay đổi auth mode phải tạo soul mới.
+
+---
+
+## Xem thêm
+
+- [Lớp 4 — Write Pipeline](04_write-pipeline.md) — policy tail được đọc và áp dụng tại bước nào
+- [Lớp 6 — PoW](06_pow.md) — chi tiết proof-of-work, canonical block, anti-replay
+- [Lớp 8 — ZACP Integration](08_zacp.md) — protocol thực tế dùng các chế độ này như thế nào

--- a/docs/pen/06_pow.md
+++ b/docs/pen/06_pow.md
@@ -1,0 +1,185 @@
+---
+name: PEN — Lớp 6: Proof-of-Work
+description: Canonical block, SHA-256 mining, anti-replay binding, PoW config encoding
+type: project
+---
+
+# Lớp 6 — PoW: Canonical Block & Anti-Replay
+
+> **Ý tưởng cốt lõi**: PoW trong PEN không chỉ là "tìm số ngẫu nhiên" như Bitcoin. Nonce được **bind chặt vào (soul + key + val + state)** — nghĩa là mỗi write yêu cầu một nonce riêng, không tái dùng được.
+
+---
+
+## Bối cảnh: Tại sao cần PoW?
+
+Trong hệ thống decentralized, không có server để rate-limit request. Bất kỳ ai cũng có thể:
+- Tạo vô số account giả (Sybil attack)
+- Gửi hàng nghìn message vào inbox của Alice
+- Flood relay network
+
+PoW giải quyết bằng cách: **gửi 1 message tốn N ms CPU**. Gửi 1000 messages → tốn 1000*N ms. Không cần server, không cần identity.
+
+---
+
+## Canonical Block — Cấu trúc dữ liệu cần hash
+
+Trước khi mining, writer xây dựng "canonical block" — một JSON object có thứ tự field cố định:
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'fontSize': '14px'}}}%%
+graph TD
+    subgraph BLOCK["Canonical Block (JSON.stringify — key order cố định)"]
+        B1["'#' : soul\n(full soul string)"]
+        B2["'.' : key\n(key đang ghi)"]
+        B3["':' : val\n(value đang ghi)"]
+        B4["'>' : state\n(HAM timestamp)"]
+    end
+
+    BLOCK --> PROOF["proof = JSON(block) + ':' + nonce"]
+    PROOF --> HASH["SHA-256(proof)"]
+    HASH --> CHK{"hash bắt đầu bằng\nunit.repeat(difficulty)?"}
+    CHK -->|"Chưa"| INC["nonce++\nthử lại"]
+    INC --> PROOF
+    CHK -->|"Đúng"| OK["✅ Nonce hợp lệ — nạp vào R[7]"]
+
+    OK --> WHY
+
+    subgraph WHY["Tại sao bind vào cả 4 fields? (anti-replay)"]
+        W1["soul: replay sang\nsoul khác → invalid"]
+        W2["key: replay sang\nkey khác → invalid"]
+        W3["val: đổi value\n→ phải mine lại"]
+        W4["state: HAM update\n→ phải mine lại"]
+    end
+
+    style BLOCK fill:#1E293B,color:#fff
+    style PROOF fill:#1E293B,color:#94A3B8
+    style HASH fill:#1E293B,color:#94A3B8
+    style CHK fill:#FEF3C7,stroke:#F59E0B,color:#78350F
+    style INC fill:#FEE2E2,stroke:#EF4444,color:#7F1D1D
+    style OK fill:#16A34A,color:#fff
+    style WHY fill:#7C3AED,color:#fff
+    style W1 fill:#EDE9FE,stroke:#A78BFA,color:#4C1D95
+    style W2 fill:#EDE9FE,stroke:#A78BFA,color:#4C1D95
+    style W3 fill:#EDE9FE,stroke:#A78BFA,color:#4C1D95
+    style W4 fill:#EDE9FE,stroke:#A78BFA,color:#4C1D95
+    linkStyle 0 stroke:#94A3B8,stroke-width:2px
+    linkStyle 1 stroke:#94A3B8,stroke-width:2px
+    linkStyle 2 stroke:#F59E0B,stroke-width:2px
+    linkStyle 3 stroke:#EF4444,stroke-width:2px
+    linkStyle 4 stroke:#EF4444,stroke-width:2px
+    linkStyle 5 stroke:#22C55E,stroke-width:2px
+    linkStyle 6 stroke:#A78BFA,stroke-width:2px
+```
+
+---
+
+## Ví dụ mining thực tế
+
+```javascript
+// Soul: !abc.../dm/alice_pub
+// Key: 12345678  (candle timestamp)
+// Val: "Hello Alice"
+// State: 1700000001234.5 (HAM timestamp)
+
+var block = JSON.stringify({
+  '#': '!abc.../dm/alice_pub',
+  '.': '12345678',
+  ':': 'Hello Alice',
+  '>': 1700000001234.5
+})
+// → '{"#":"!abc.../dm/alice_pub",".":"12345678",":":"Hello Alice",">":1700000001234.5}'
+
+var nonce = 0
+while (true) {
+  var hash = sha256(block + ':' + nonce)
+  if (hash.startsWith('0')) break  // difficulty=1, unit='0'
+  nonce++
+}
+// Kết quả: nonce = 47 (ví dụ)
+// Gửi write với ctx.put['^'] = 47 → nạp vào R[7]
+```
+
+---
+
+## PoW Config Encoding trong Bytecode
+
+```
+[0xC4][field=7][difficulty:u8][unitlen:u8][unit bytes...]
+  ↑       ↑          ↑              ↑           ↑
+Policy  R[7] là    Số lần unit    Số bytes    Ký tự unit
+ tail   nonce      lặp trong      trong unit  (ASCII)
+ byte             hash prefix
+```
+
+**Ví dụ cụ thể:**
+```
+difficulty=2, unit='0'  →  hash phải bắt đầu bằng "00"
+difficulty=3, unit='0'  →  hash phải bắt đầu bằng "000"  (khó hơn ~16x)
+difficulty=1, unit='00' →  hash phải bắt đầu bằng "00"   (giống trên)
+```
+
+---
+
+## Anti-Replay — 3 lớp bảo vệ
+
+### Lớp 1: Không tái dùng nonce sang soul khác
+
+```
+Nonce đúng cho:  soul=!abc.../dm/alice  + key=123 + val="Hi"
+Copy sang:       soul=!xyz.../dm/bob    + key=123 + val="Hi"
+
+→ Block JSON khác → SHA-256 khác → prefix không match → FAIL
+```
+
+### Lớp 2: Không tái dùng khi thay đổi value
+
+```
+Nonce N hợp lệ cho:  val = "Hello Alice"
+Sau đó thay đổi:     val = "Hello Alice. PS: ..."
+
+→ Block JSON khác → phải mine nonce mới
+```
+
+### Lớp 3: HAM state update tự invalidate nonce cũ
+
+```
+Nonce N hợp lệ cho:  state = 1700000001234.5
+HAM nhận write → state tăng lên 1700000001235.0
+Attacker cố replay nonce N:
+
+→ state trong block khác → SHA-256 khác → FAIL
+```
+
+---
+
+## PoW trong thực tế — Độ khó vs. Chi phí
+
+| Difficulty | Unit   | Expected hashes | Thời gian ~ (js) |
+| ---------- | ------ | --------------- | ---------------- |
+| 1          | `"0"`  | 16              | < 1ms            |
+| 2          | `"0"`  | 256             | ~5ms             |
+| 3          | `"0"`  | 4096            | ~80ms            |
+| 1          | `"00"` | 256             | ~5ms             |
+| 2          | `"00"` | 65536           | ~1.3s            |
+
+**DM soul trong ZACP** dùng `difficulty=1, unit='0'` — đủ để làm chậm spammer nhưng không annoying cho người dùng thật.
+
+---
+
+## Giới hạn của PoW trong PEN
+
+| Vấn đề                 | Chi tiết                                                          |
+| ---------------------- | ----------------------------------------------------------------- |
+| **Difficulty cố định** | Bytecode baked vào soul → không thể tăng difficulty khi spam tăng |
+| **Hardware advantage** | GPU/ASIC mine nhanh hơn nhiều → người giàu có thể spam nhiều hơn  |
+| **Không adaptive**     | Muốn thay đổi difficulty phải tạo soul mới + migrate              |
+
+> Đây là trade-off thiết kế: simplicity vs. adaptive security. Với use case messaging thông thường, fixed difficulty là đủ.
+
+---
+
+## Xem thêm
+
+- [Lớp 5 — Policy Tail](05_policy-tail.md) — PoW là 1 trong 4 policy mode
+- [Lớp 4 — Write Pipeline](04_write-pipeline.md) — mining xảy ra ở bước ③, verify ở bước ⑥
+- [Lớp 8 — ZACP Integration](08_zacp.md) — DM soul dùng PoW + sign kết hợp

--- a/docs/pen/07_compiler-dsl.md
+++ b/docs/pen/07_compiler-dsl.md
@@ -1,0 +1,224 @@
+---
+name: PEN — Lớp 7: Compiler DSL
+description: ZEN.pen(spec) — high-level JS spec biên dịch thành bytecode, cách viết policy không cần hiểu ISA
+type: project
+---
+
+# Lớp 7 — Compiler DSL: Cách viết policy
+
+> **Ý tưởng cốt lõi**: Không ai muốn viết bytecode tay. `ZEN.pen(spec)` nhận một JS object mô tả policy bằng ngôn ngữ tự nhiên, biên dịch thành bytecode, và trả về soul string sẵn sàng để dùng.
+
+---
+
+## Luồng biên dịch
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'fontSize': '14px', 'lineColor': '#94A3B8'}}}%%
+graph TD
+    subgraph SPEC["  High-level Spec (JS object)  "]
+        direction LR
+        K["key: { pre: 'msg_' }\nValidate R[0]"]
+        V["val: { type: 'string', length: [1, 280] }\nValidate R[1]"]
+        P["path: 'alice_pubkey'\nValidate R[6]"]
+        AUTH_OPTS["sign: true\ncert: owner_pub\nopen: true\npow: { unit: '0', difficulty: 1 }"]
+    end
+
+    subgraph COMPILER["pen.js Compiler (src/pen.js)"]
+        C1["Compile từng field\n→ opcodes"]
+        C2["AND tất cả fields\nlại với nhau"]
+        C3["Append policy\ntail bytes"]
+        C4["base62 encode\ntổng bytecode"]
+        C1 --> C2 --> C3 --> C4
+    end
+
+    subgraph OUTPUT["Output"]
+        SOUL2["Soul string\n'!xK9mPqR2.../path'"]
+        USE["zen.get(soul).put(val)\nMọi write tự động validated"]
+        SOUL2 --> USE
+    end
+
+    SPEC --> COMPILER --> OUTPUT
+
+    style K fill:#1D4ED8,stroke:#93C5FD,stroke-width:1.5px,color:#EFF6FF
+    style V fill:#1D4ED8,stroke:#93C5FD,stroke-width:1.5px,color:#EFF6FF
+    style P fill:#1D4ED8,stroke:#93C5FD,stroke-width:1.5px,color:#EFF6FF
+    style AUTH_OPTS fill:#15803D,stroke:#86EFAC,stroke-width:1.5px,color:#F0FDF4
+    style C1 fill:#B45309,stroke:#FCD34D,stroke-width:1.5px,color:#FFFBEB
+    style C2 fill:#B45309,stroke:#FCD34D,stroke-width:1.5px,color:#FFFBEB
+    style C3 fill:#B45309,stroke:#FCD34D,stroke-width:1.5px,color:#FFFBEB
+    style C4 fill:#B45309,stroke:#FCD34D,stroke-width:1.5px,color:#FFFBEB
+    style SOUL2 fill:#6B21A8,stroke:#D8B4FE,stroke-width:1.5px,color:#FAF5FF
+    style USE fill:#6B21A8,stroke:#D8B4FE,stroke-width:1.5px,color:#FAF5FF
+```
+
+---
+
+## Anatomy của một spec
+
+```javascript
+const soul = ZEN.pen({
+  // ── Validate KEY (R[0]) ──────────────────────────────────────
+  key: {
+    pre: 'tweet_',         // key phải bắt đầu bằng "tweet_"
+    suf: '.json',          // key phải kết thúc bằng ".json"
+    length: [1, 64],       // độ dài 1–64 ký tự
+    type: 'string',        // phải là string
+    eq: 'fixed_key',       // phải bằng đúng giá trị này
+  },
+
+  // ── Validate VALUE (R[1]) ─────────────────────────────────────
+  val: {
+    type: 'string',        // phải là string
+    length: [1, 280],      // 1–280 ký tự
+    pre: 'https://',       // phải bắt đầu bằng URL
+    and: [                 // kết hợp nhiều điều kiện
+      { type: 'string' },
+      { length: [1, 280] }
+    ],
+    or: [                  // ít nhất 1 điều kiện đúng
+      { type: 'string' },
+      { type: 'number' }
+    ],
+  },
+
+  // ── Validate PATH (R[6]) ──────────────────────────────────────
+  path: alice_pubkey,      // path segment phải bằng pubkey này
+                           // → trở thành EQ(R[6], alice_pubkey)
+
+  // ── Auth mode (policy tail) ───────────────────────────────────
+  sign: true,              // 0xC0 SGN — writer phải có private key
+  cert: owner_pubkey,      // 0xC1 CRT — writer cần cert từ owner
+  open: true,              // 0xC3 NOA — ai cũng ghi được
+  pow: {                   // 0xC4 PoW
+    unit: '0',
+    difficulty: 1
+  },
+  // Chỉ 1 trong 4 được dùng — nếu nhiều hơn, sign > cert > pow > open
+})
+```
+
+---
+
+## Ví dụ thực tế
+
+### Twitter-like tweet soul
+
+```javascript
+const tweetSoul = ZEN.pen({
+  key: { pre: 'tweet_' },
+  val: {
+    and: [
+      { type: 'string' },
+      { length: [1, 280] }
+    ]
+  },
+  path: alice_pubkey,
+  sign: true
+})
+// soul = "!<bytecode>/alice_pubkey"
+// Chỉ Alice có thể ghi tweet, key phải bắt đầu bằng "tweet_",
+// val phải là string 1–280 ký tự
+```
+
+### Anti-spam inbox
+
+```javascript
+const inbox = ZEN.pen({
+  path: recipient_pubkey,
+  key: { type: 'number' },   // candle timestamp
+  sign: true,                // sender phải có identity
+  pow: { unit: '0', difficulty: 1 }  // + phải mine PoW
+})
+// Gửi vào inbox phải: có private key + mine PoW
+```
+
+### Invite-only channel
+
+```javascript
+const channel = ZEN.pen({
+  path: `${project_id}/${channel_id}`,
+  key: { type: 'number' },   // candle timestamp
+  sign: true,
+  cert: admin_pubkey         // cần cert từ admin
+})
+// Admin cấp cert cho mỗi member → member ghi được
+```
+
+### Public collaborative doc
+
+```javascript
+const doc = ZEN.pen({
+  key: { and: [
+    { type: 'string' },
+    { length: [1, 64] }
+  ]},
+  val: { length: [0, 1024] },
+  open: true                 // ai cũng ghi được
+})
+```
+
+---
+
+## Compiler internals — Cách spec → bytecode
+
+### Bước 1: Compile từng field thành opcode tree
+
+```
+key: { pre: 'tweet_' }
+  → PRE(REG(0), STR("tweet_"))
+  → [0xF0][0x56][0x03][0x07]['t']['w']['e']['e']['t']['_']
+```
+
+```
+val: { and: [{ type: 'string' }, { length: [1, 280] }] }
+  → AND(ISS(REG(1)), LNG(REG(1), 1, 280))
+  → [0x20][0x02][0xF1][0x60][0xF1][0x64][0x01][0x18 0x02]
+                                                ↑    ↑
+                                               1    280 (ULEB128: 280 = 0x18 + 0x02<<7)
+```
+
+### Bước 2: AND tất cả field conditions
+
+Nếu có 3 field checks (key, val, path):
+```
+AND(3, [key_expr, val_expr, path_expr])
+→ [0x20][0x03][key_opcodes...][val_opcodes...][path_opcodes...]
+```
+
+### Bước 3: Append policy tail
+
+```
+sign: true → append [0xC0]
+cert: pubkey → append [0xC1][len][pubkey_bytes]
+open: true → append [0xC3]
+pow: config → append [0xC4][7][difficulty][unitlen][unit]
+```
+
+### Bước 4: base62 encode
+
+```javascript
+var full = [0x01, ...expr_bytes, ...tail_bytes]
+var soul = '!' + base62(full) + '/' + (path_value || '')
+```
+
+---
+
+## Debugging — Đọc lại spec từ soul
+
+Hiện tại không có công cụ official để decode soul → spec. Đây là một trong những **điểm yếu** của PEN: bytecode opaque, khó debug bằng mắt.
+
+Workaround: Lưu lại spec object cùng với soul khi tạo.
+
+```javascript
+const spec = { key: { pre: 'tweet_' }, val: { length: [1, 280] }, sign: true }
+const soul = ZEN.pen(spec)
+// Lưu: { soul, spec } để sau debug
+```
+
+---
+
+## Xem thêm
+
+- [Lớp 1 — Soul Encoding](01_soul-encoding.md) — soul string output của compiler trông như thế nào
+- [Lớp 2 — ISA](02_isa.md) — các opcodes được emit ra
+- [Lớp 8 — ZACP Integration](08_zacp.md) — protocol dùng compiler để tạo các soul chuẩn

--- a/docs/pen/08_zacp.md
+++ b/docs/pen/08_zacp.md
@@ -1,0 +1,227 @@
+---
+name: PEN — Lớp 8: ZACP Integration
+description: Protocol (lib/protocol.js) dùng PEN để tạo inbox, channel, DM souls — candle key, soul factories
+type: project
+---
+
+# Lớp 8 — ZACP Integration: Protocol dùng PEN như thế nào
+
+> **Ý tưởng cốt lõi**: ZACP (Zen Application Communication Protocol) là lớp application build trên PEN. Thay vì mỗi developer tự thiết kế policy, ZACP cung cấp 3 soul factory chuẩn hóa cho 3 use case phổ biến nhất.
+
+---
+
+## Ba soul factory của ZACP
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'fontSize': '15px', 'primaryColor': '#1E293B', 'primaryTextColor': '#fff', 'lineColor': '#94A3B8'}}}%%
+graph TD
+    ZACP{{"ZACP Protocol\nlib/protocol.js"}}
+
+    ZACP --> INBOX["📬 inboxSoul(pub)\n─────────────────\npath: recipient_pub\nkey:  candle window\nsign: true\npow:  optional"]
+
+    ZACP --> CHAN["📢 chanSoul(proj, chan, owner)\n─────────────────────────────\npath: proj/&lt;id&gt;/chan/&lt;id&gt;\nkey:  candle window\nsign: true\ncert: owner_pub"]
+
+    ZACP --> DM["💬 dmSoul(recipient)\n────────────────────\npath: dm/recipient_pub\nkey:  candle window\nsign: true\npow:  {unit:'0', difficulty:1}"]
+
+    INBOX --> CANDLE["🕯️ candle(opts)\n───────────────────────────────────────\nkey = ⌊Date.now() / size⌋\naccept: key ∈ [now/size − back, now/size]\n→ time-windowed write · anti-replay"]
+
+    CHAN --> CANDLE
+    DM --> CANDLE
+
+    style ZACP fill:#0F172A,stroke:#475569,stroke-width:2px,color:#F8FAFC
+    style INBOX fill:#1D4ED8,stroke:#93C5FD,stroke-width:1.5px,color:#EFF6FF
+    style CHAN fill:#B45309,stroke:#FCD34D,stroke-width:1.5px,color:#FFFBEB
+    style DM fill:#15803D,stroke:#86EFAC,stroke-width:1.5px,color:#F0FDF4
+    style CANDLE fill:#6B21A8,stroke:#D8B4FE,stroke-width:1.5px,color:#FAF5FF
+```
+
+---
+
+## Candle Key — Cơ chế thời gian trong key
+
+Đây là concept then chốt của ZACP: **key là một timestamp được rounding về "nến" (candle)**.
+
+```javascript
+// Candle size mặc định: 5 phút = 300,000ms
+const candleIndex = Math.floor(Date.now() / 300000)
+// Ví dụ: Date.now() = 1700000301234 → candleIndex = 5666667
+
+// Writer dùng candleIndex làm key
+zen.get(soul).get(candleIndex).put(message)
+```
+
+**Predicate trong soul kiểm tra:**
+```
+key phải nằm trong cửa sổ [now/size - back, now/size + fwd]
+```
+
+Ví dụ với `back=2, fwd=1`:
+```
+Candle hiện tại: 5666667
+Cho phép key:   5666665, 5666666, 5666667, 5666668
+Reject:         5666664 (quá cũ), 5666669 (quá xa tương lai)
+```
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'fontSize': '14px'}}}%%
+graph LR
+    TIME["Timeline (mỗi ô = 5 phút)"]
+
+    subgraph OLD["Quá cũ → REJECT"]
+        C1["nến -3"]
+        C2["nến -2 (back limit)"]
+    end
+
+    subgraph WINDOW["Cửa sổ hợp lệ → ACCEPT"]
+        C3["nến -1"]
+        C4["nến 0 (hiện tại)"]
+        C5["nến +1 (fwd limit)"]
+    end
+
+    subgraph FUTURE["Quá xa → REJECT"]
+        C6["nến +2"]
+    end
+
+    OLD --> WINDOW --> FUTURE
+
+    style WINDOW fill:#16A34A,color:#fff
+    style OLD fill:#DC2626,color:#fff
+    style FUTURE fill:#DC2626,color:#fff
+```
+
+**Tại sao cần fwd (future tolerance)?** Clock drift giữa các peer. Alice ở múi giờ khác có thể thấy "current candle" lệch 1 nến so với Bob.
+
+---
+
+## inboxSoul — Hòm thư cá nhân
+
+```javascript
+// lib/protocol.js
+function inboxSoul(recipientPub, opts) {
+  return ZEN.pen({
+    path: recipientPub,
+    key: candle({ size: 300000, back: 3, fwd: 1 }),
+    sign: true,
+    ...(opts?.pow && { pow: opts.pow })
+  })
+}
+```
+
+**Ai ghi được:** Bất kỳ ai có private key (signed) + key trong cửa sổ candle.
+
+**Ai đọc được:** Bất kỳ ai (read không bị policy kiểm soát).
+
+**Ý đồ:** Alice public inbox của mình. Bob gửi message vào. Alice đọc. Bot spam → cần thêm `pow` option.
+
+```javascript
+// Gửi message vào inbox của Alice
+const inbox = inboxSoul(alice_pub)
+await zen.get(inbox).get(candleKey()).put({
+  from: bob_pub,
+  text: "Hey Alice!",
+  sig: await ZEN.sign("Hey Alice!", bob_pair)
+})
+```
+
+---
+
+## chanSoul — Channel nhóm (invite-only)
+
+```javascript
+function chanSoul(projectId, channelId, ownerPub) {
+  return ZEN.pen({
+    path: `${projectId}/${channelId}`,
+    key: candle({ size: 300000, back: 3, fwd: 1 }),
+    sign: true,
+    cert: ownerPub           // phải có cert từ owner
+  })
+}
+```
+
+**Ai ghi được:** Ai có cert được owner cấp + có private key + key trong cửa sổ.
+
+**Flow membership:**
+```
+1. Admin tạo chanSoul với admin_pub
+2. Admin cấp cert cho Bob: cert = ZEN.sign(bob_pub, admin_pair)
+3. Bob ghi vào channel kèm cert
+4. Peer verify: cert hợp lệ từ admin? → accept
+```
+
+---
+
+## dmSoul — Direct Message (anti-spam)
+
+```javascript
+function dmSoul(recipientPub) {
+  return ZEN.pen({
+    path: `dm/${recipientPub}`,
+    key: candle({ size: 300000, back: 3, fwd: 1 }),
+    sign: true,
+    pow: { unit: '0', difficulty: 1 }  // phải mine PoW
+  })
+}
+```
+
+**Ai ghi được:** Ai có private key + đã mine PoW + key trong cửa sổ.
+
+**Tại sao cả sign lẫn pow?**
+- `sign`: biết message đến từ ai (accountability)
+- `pow`: anti-spam (tốn CPU mỗi message)
+
+```javascript
+// Gửi DM cho Alice
+const dm = dmSoul(alice_pub)
+const key = candleKey()
+await zen.get(dm).get(key).put(message, null, { pow: true })
+//                                              ↑ bật auto-mine
+```
+
+---
+
+## Tổng hợp — So sánh 3 soul
+
+| | inboxSoul | chanSoul | dmSoul |
+|--|-----------|----------|--------|
+| **Path** | recipient_pub | proj/chan | dm/recipient_pub |
+| **Auth** | sign | sign + cert | sign + pow |
+| **Ai ghi được** | Bất kỳ ai có key | Member được invite | Bất kỳ ai (tốn CPU) |
+| **Chống spam** | Không (thêm pow tùy chọn) | Có (invite-only) | Có (PoW) |
+| **Revoke member** | Không được | Không được | — |
+
+---
+
+## Candle — Chi tiết implementation
+
+```javascript
+function candle(opts) {
+  var size = opts.size || 300000   // 5 phút
+  var back = opts.back || 3        // cho phép 3 nến cũ
+  var fwd  = opts.fwd  || 1        // cho phép 1 nến tương lai
+
+  return {
+    // Được compiler PEN biên dịch thành:
+    // SEGRN(R[0]) nằm trong [now/size - back, now/size + fwd]
+    and: [
+      { gte: [{ seg: [{ reg: 0 }, '_', 1], tonum: true },
+              { sub: [{ div: [{ reg: 4 }, size] }, back] }] },
+      { lte: [{ seg: [{ reg: 0 }, '_', 1], tonum: true },
+              { add: [{ div: [{ reg: 4 }, size] }, fwd] }] }
+    ]
+  }
+}
+
+// Tạo key cho write hiện tại
+function candleKey(size) {
+  return Math.floor(Date.now() / (size || 300000))
+}
+```
+
+---
+
+## Xem thêm
+
+- [Lớp 5 — Policy Tail](05_policy-tail.md) — SGN, CRT, PoW được dùng trong 3 soul trên
+- [Lớp 6 — PoW](06_pow.md) — dmSoul dùng PoW như thế nào
+- [Lớp 7 — Compiler DSL](07_compiler-dsl.md) — ZACP souls được biên dịch bởi ZEN.pen()
+- [00 — Overview](00_pen-deepdive.md) — Mental model tổng kết


### PR DESCRIPTION
## Summary

- Adds `docs/pen/` with 9 files documenting PEN Policy VM internals
- Covers soul encoding, ISA, registers, write pipeline, policy tail, PoW, compiler DSL, and ZACP
- Makes internal architecture knowledge part of the tracked repo rather than local Claude context

## Why

PEN is the security enforcement layer at the core of ZEN's write model.
Having its internals versioned alongside the source makes it easier for
contributors to understand write rules, extend the compiler DSL, or audit
policy enforcement behavior.