### PR TITLE
Add pub index and tighten pexList filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ tmp/
 .well-known/
 playwright-report/
 test-results/
+.agents/
+.claude/
+_bmad/
+_bmad-output/

--- a/lib/peer-registry.js
+++ b/lib/peer-registry.js
@@ -162,11 +162,12 @@ class PeerRegistry {
                 const now = Date.now();
                 alias.lastOk = now;
                 alias.seen   = now;
-                if (opts.pub) alias.pub = opts.pub;
+                alias.pub = opts.pub;
                 if (opts.pid) alias.pid = opts.pid;
               }
             }
             n = existing;
+          }
         }
       } else {
         this._pubIndex.set(opts.pub, n);

--- a/lib/peer-registry.js
+++ b/lib/peer-registry.js
@@ -134,16 +134,31 @@ class PeerRegistry {
    * Optionally attach remote pub and pid for WATCHDOG identity checks.
    */
   confirm(url, opts = {}) {
-    const [n] = both(url);
+    let [n] = both(url);
     if (opts.pub) {
       const existing = this._pubIndex.get(opts.pub);
       if (existing && existing !== n) {
-        // Same pub key behind a different hostname — wildcard-DNS alias. Evict the duplicate.
-        this._map.delete(n);
-        this._scheduleSave();
-        return;
+        // Same pub key behind a different hostname — wildcard-DNS alias.
+        if (!this._map.has(existing)) {
+          // Stale index (canonical entry was evicted/removed) — re-point to this URL.
+          this._pubIndex.set(opts.pub, n);
+        } else {
+          const existingProtected = this._boot.has(existing) || this._self.has(existing);
+          const nProtected = this._boot.has(n) || this._self.has(n);
+
+          if (nProtected && !existingProtected) {
+            // Prefer protected URLs (BOOT/self) over an unprotected earlier mapping.
+            this._map.delete(existing);
+            this._pubIndex.set(opts.pub, n);
+          } else {
+            // Keep the first-confirmed canonical URL; still record this confirmation on it.
+            if (!nProtected) this._map.delete(n);
+            n = existing;
+          }
+        }
+      } else {
+        this._pubIndex.set(opts.pub, n);
       }
-      this._pubIndex.set(opts.pub, n);
     }
     const entry = this._map.get(n);
     const now = Date.now();

--- a/lib/peer-registry.js
+++ b/lib/peer-registry.js
@@ -152,9 +152,21 @@ class PeerRegistry {
             // Keep the first-confirmed canonical URL; redirect this confirmation onto it.
             // Non-protected duplicates are deleted; protected (BOOT/self) duplicates
             // remain in _map (BOOT contract) but are excluded from pexList via _pubIndex check.
-            if (!nProtected) this._map.delete(n);
+            if (!nProtected) {
+              this._map.delete(n);
+            } else {
+              // Still mark the protected alias as confirmed so bootEntries()/watchdog can
+              // detect inbound-only live connections by pub/pid.
+              const alias = this._map.get(n);
+              if (alias) {
+                const now = Date.now();
+                alias.lastOk = now;
+                alias.seen   = now;
+                if (opts.pub) alias.pub = opts.pub;
+                if (opts.pid) alias.pid = opts.pid;
+              }
+            }
             n = existing;
-          }
         }
       } else {
         this._pubIndex.set(opts.pub, n);

--- a/lib/peer-registry.js
+++ b/lib/peer-registry.js
@@ -138,20 +138,20 @@ class PeerRegistry {
     if (opts.pub) {
       const existing = this._pubIndex.get(opts.pub);
       if (existing && existing !== n) {
-        // Same pub key behind a different hostname — wildcard-DNS alias.
         if (!this._map.has(existing)) {
-          // Stale index (canonical entry was evicted/removed) — re-point to this URL.
+          // Stale index (canonical entry was evicted) — re-point to this URL.
           this._pubIndex.set(opts.pub, n);
         } else {
           const existingProtected = this._boot.has(existing) || this._self.has(existing);
-          const nProtected = this._boot.has(n) || this._self.has(n);
-
+          const nProtected        = this._boot.has(n)        || this._self.has(n);
           if (nProtected && !existingProtected) {
-            // Prefer protected URLs (BOOT/self) over an unprotected earlier mapping.
+            // Prefer BOOT/self URLs over an unprotected earlier mapping.
             this._map.delete(existing);
             this._pubIndex.set(opts.pub, n);
           } else {
-            // Keep the first-confirmed canonical URL; still record this confirmation on it.
+            // Keep the first-confirmed canonical URL; redirect this confirmation onto it.
+            // Non-protected duplicates are deleted; protected (BOOT/self) duplicates
+            // remain in _map (BOOT contract) but are excluded from pexList via _pubIndex check.
             if (!nProtected) this._map.delete(n);
             n = existing;
           }
@@ -237,7 +237,13 @@ class PeerRegistry {
    */
   pexList(max = 50, rttOf = null) {
     return Array.from(this._map.values())
-      .filter(e => !e.isSelf && e.url && (e.lastOk > 0 || e.isBoot))
+      .filter(e => {
+        if (e.isSelf || !e.url) return false;
+        if (!e.isBoot && e.lastOk === 0) return false;
+        // Exclude BOOT aliases: BOOT entry whose pub canonically maps to a different URL.
+        if (e.isBoot && e.pub && this._pubIndex.get(e.pub) !== e.url) return false;
+        return true;
+      })
       .sort((a, b) => {
         const as = a.url.startsWith("wss://") ? 0 : 1;
         const bs = b.url.startsWith("wss://") ? 0 : 1;
@@ -262,6 +268,9 @@ class PeerRegistry {
       if (entry.isBoot || entry.isSelf) continue;
       if (now - entry.seen > this.TTL && now - entry.lastOk > this.TTL) {
         this._map.delete(url);
+        if (entry.pub && this._pubIndex.get(entry.pub) === url) {
+          this._pubIndex.delete(entry.pub);
+        }
       }
     }
   }

--- a/lib/peer-registry.js
+++ b/lib/peer-registry.js
@@ -68,7 +68,8 @@ class PeerRegistry {
   constructor(opts = {}) {
     // Map<canonicalUrl, PeerEntry>
     // PeerEntry: { url, seen, lastOk, pub, pid, isBoot, isSelf }
-    this._map  = new Map();
+    this._map      = new Map();
+    this._pubIndex = new Map(); // pub → first-confirmed canonicalUrl (dedup wildcard-DNS aliases)
     this._boot = new Set(); // canonical URLs of BOOT peers (never evicted)
     this._self = new Set(); // canonical URLs of self (excluded from PEX + save)
     this.TTL   = opts.TTL != null ? opts.TTL : 30 * 60 * 1000;
@@ -134,6 +135,16 @@ class PeerRegistry {
    */
   confirm(url, opts = {}) {
     const [n] = both(url);
+    if (opts.pub) {
+      const existing = this._pubIndex.get(opts.pub);
+      if (existing && existing !== n) {
+        // Same pub key behind a different hostname — wildcard-DNS alias. Evict the duplicate.
+        this._map.delete(n);
+        this._scheduleSave();
+        return;
+      }
+      this._pubIndex.set(opts.pub, n);
+    }
     const entry = this._map.get(n);
     const now = Date.now();
     if (entry) {
@@ -211,7 +222,7 @@ class PeerRegistry {
    */
   pexList(max = 50, rttOf = null) {
     return Array.from(this._map.values())
-      .filter(e => !e.isSelf && e.url)
+      .filter(e => !e.isSelf && e.url && (e.lastOk > 0 || e.isBoot))
       .sort((a, b) => {
         const as = a.url.startsWith("wss://") ? 0 : 1;
         const bs = b.url.startsWith("wss://") ? 0 : 1;


### PR DESCRIPTION
Introduce a _pubIndex map to PeerRegistry to deduplicate peers by pub key (prefer the first-confirmed canonical URL). In confirm(), if opts.pub is provided and maps to a different canonical URL, evict the duplicate entry and schedule a save; otherwise record the pub→canonical mapping. Also restrict pexList to only include peers that are either boot nodes or have a successful lastOk (exclude peers with no successful contact), while still excluding self and requiring a url. Minor whitespace adjustments.