### PR TITLE
docs(storage): add §5.14 on node-shaped storage cost

### DIFF
--- a/docs/ch05-storage.md
+++ b/docs/ch05-storage.md
@@ -361,3 +361,67 @@ GUN_TEST_TMP=1 npm run test:core
 
 # Or use npm run clean + npm test (does both automatically)
 ```
+
+---
+
+## 5.14 Shaping data for storage cost
+
+**The unit of cost is the node, not the byte.** Every node is a separate unit of signing, syncing and storage, so it carries a fixed overhead that does not shrink with the amount of data in it. If you arrive from a relational background, "one record, one node" is the natural first instinct — and it is the slowest possible layout.
+
+### 5.14.1 Batch small records
+
+Same data, two shapes — 200 candles, signed writes to `~<pub>` with `radisk: true`:
+
+| Layout | Write | Read |
+|--------|-------|------|
+| One node per record (`~pub/c/<ts>`) | 200 in 8628 ms = **23/s** | 200 in 23181 ms = **9/s** |
+| One node holding 1440 records (110.5 KB JSON) | 325 ms = **4431/s** | 157 ms = **9172/s** |
+
+The per-node cost is **flat**, not degrading — writing the 150th child of a node costs the same as the first (measured 47 / 41 / 42 ms for children 1-10, 71-80, 141-150; reads 109 / 113 / 113 ms). There is no fan-out penalty to design around; there is simply a floor per node that you pay once per node.
+
+So when you have many small records that are always read together, pack them:
+
+```js
+// Slow: one node per candle
+for (const c of candles) {
+  zen.get("~" + pub).get("c").get(String(c.ts)).put(c, null, { authenticator: me });
+}
+
+// Fast: one node per day
+zen.get("~" + pub).get("day").get("2026-01-01").put(
+  { count: candles.length, data: JSON.stringify(candles) },
+  null,
+  { authenticator: me },
+);
+```
+
+Batch when records are written and read as a group and you do not need per-record subscriptions. Keep one node per record when subscribers need to react to individual records, or when writers of different records are different identities.
+
+### 5.14.2 When you do read many nodes, read them in parallel
+
+Most of the per-read cost is **latency, not CPU**. `once()` debounces before it delivers, `opt.wait || 99` ms (`src/on.js`), and that wait is paid even for a node already in memory. Awaiting reads one at a time serialises that wait; issuing them together does not:
+
+| Reading 60 nodes | Throughput |
+|------------------|-----------|
+| Sequential `await`, default | 9 nodes/s |
+| Sequential `await`, `{ wait: 0 }` | 10 nodes/s |
+| Parallel | **176 nodes/s** |
+
+Note that `{ wait: 0 }` does not remove the floor — parallelism does.
+
+```js
+const read = (chain) => new Promise((done) => chain.once(done));
+
+// Slow: each await pays the full latency
+const slow = [];
+for (const ts of timestamps) {
+  slow.push(await read(zen.get("~" + pub).get("c").get(ts)));
+}
+
+// ~19x faster: one round of latency for all of them
+const fast = await Promise.all(
+  timestamps.map((ts) => read(zen.get("~" + pub).get("c").get(ts))),
+);
+```
+
+Absolute numbers above are from one machine (Node 24, ext4, `radisk` + `rfs`, signed writes) and will differ on yours — the ratios are the part worth remembering.


### PR DESCRIPTION
Sửa mục 3 của #35 — thêm §5.14 vào `docs/ch05-storage.md`.

## Nội dung

**§5.14.1 — đơn vị tốn kém là node, không phải byte.** Kèm bảng cùng một lượng dữ liệu xếp hai kiểu (200 nến, ghi có chữ ký vào `~pub`, `radisk: true`): mỗi nến một node = 23 ghi/s và 9 đọc/s; một node chứa 1440 nến (110,5 KB) = 4431 ghi/s và 9172 đọc/s. Kèm ví dụ mã cho cả hai cách xếp, và hướng dẫn khi nào nên gói theo lô, khi nào nên giữ một node một bản ghi (cần subscribe từng bản ghi, hoặc người ghi là các danh tính khác nhau).

**Chi phí mỗi node là phẳng, không suy giảm.** Đo được 47 / 41 / 42 ms cho node con thứ 1-10, 71-80, 141-150 dưới cùng một cha; đọc 109 / 113 / 113 ms. Không có "phạt fan-out" nào phải né — chỉ có một mức sàn trả một lần cho mỗi node. Điều này sửa lại nhận định trong #35 rằng phép ghi chậm dần theo số node con; hiện tượng đó thực ra là lỗi im lặng ở mục 1 (xem #36), vì script đo chạy cấu hình không có storage adapter nên mọi cú ghi đều timeout.

**§5.14.2 — phần đọc.** Phần lớn chi phí mỗi lần đọc là **độ trễ, không phải CPU**: `once()` debounce `opt.wait || 99` ms (`src/on.js`), và khoản chờ đó phải trả cả khi node đã nằm sẵn trong bộ nhớ. `await` từng cái sẽ nối tiếp các khoản chờ đó lại:

| Đọc 60 node | Thông lượng |
|---|---|
| tuần tự, mặc định | 9 node/s |
| tuần tự, `{wait: 0}` | 10 node/s |
| song song | **176 node/s** |

Nên con số 1111× ở cột đọc trong #35 chủ yếu là do `await` tuần tự chứ không phải bản chất của node — mục docs nói rõ điều này thay vì chép nguyên bảng cũ.

## Kiểm chứng

Cả hai ví dụ mã trong mục mới đã được chạy thật trên bản build hiện tại: ghi theo lô đọc lại đúng 5/5 bản ghi; hai kiểu đọc trả cùng dữ liệu, tuần tự 715ms so với song song 102ms.

Chỉ sửa tài liệu, không đụng mã nguồn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
