### PR TITLE
test: fix flaky "users map map who said map on" calling done() twice

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -4085,7 +4085,30 @@ describe("ZEN", function () {
 
       var check = {},
         c = 0,
-        end;
+        end,
+        queued = false,
+        sub;
+      // `check` is transiently empty between writes — a key is only added just
+      // before each set() — so "empty" alone does not mean the run finished.
+      // Wait for every write to be issued too, and let done() fire only once:
+      // a late emission after an early finish used to call it a second time.
+      var settle = function () {
+        clearTimeout(end);
+        end = setTimeout(function () {
+          //console.log("?", c, check, Object.keys(check), zen._.graph);
+          if (!queued || !Object.empty(check)) {
+            return;
+          } //if(Zen.obj.map(check, function(v){ if(v){ return v } })){ return }
+          if (done.c) {
+            return;
+          }
+          done.c = 1;
+          if (sub && sub.off) {
+            sub.off();
+          }
+          nopasstun(done, zen);
+        }, 9);
+      };
       //console.log(check, zen._.graph);
       zen
         .get("users/mm")
@@ -4099,22 +4122,10 @@ describe("ZEN", function () {
           if (check[msg.num]) {
             //console.log("!!!!", msg.num, "!!!!");
           }
+          sub = this;
           delete check[msg.num];
           c++;
-          clearTimeout(end);
-          end = setTimeout(
-            function () {
-              //console.log("?", c, check, Object.keys(check), zen._.graph);
-              if (!Object.empty(check)) {
-                return;
-              } //if(Zen.obj.map(check, function(v){ if(v){ return v } })){ return }
-              if (this && this.off) {
-                this.off();
-              }
-              nopasstun(done, zen);
-            }.bind(this),
-            9,
-          );
+          settle();
         });
 
       var said = zen.get("pub/asdf").get("who").get("said");
@@ -4136,7 +4147,9 @@ describe("ZEN", function () {
         m = 9,
         to = setTimeout(function frame() {
           if (m <= i) {
+            queued = true;
             clearTimeout(to);
+            settle(); // in case every emission already landed before this point
             return;
           }
           i++;


### PR DESCRIPTION
Sửa test flaky `users map map who said map on` — cái đỏ trên Windows CI với `Error: done() called multiple times`.

## Hai lỗi trong test

**1. Điều kiện kết thúc có thể đúng giữa chừng.** `check[i]` chỉ được thêm ngay trước mỗi `set()`. Nên giữa hai lệnh ghi, `check` rỗng một cách tạm thời. Nếu có một khoảng lặng >9ms rơi đúng lúc đó — GC, hoặc runner chậm/đang tải — bộ debounce 9ms kết luận "xong" trong khi mới phát được vài bản ghi.

**2. `done` không có chốt chống gọi lại.** Các test lân cận đều có `if (done.c) { return } done.c = 1`, riêng test này không. Nên bản ghi đến muộn sau lần "xong" sớm sẽ đặt lại debounce và gọi `done()` lần thứ hai → mocha báo `done() called multiple times`.

Chỉ chốt `done` thôi thì che mất lỗi 1: test sẽ xanh nhưng có thể chưa hề quan sát đủ 9 bản ghi. Nên sửa cả hai.

## Bản sửa

- Thêm cờ `queued`, bật khi vòng lặp đã phát xong cả 9 lệnh ghi. Debounce chỉ kết luận khi `queued && Object.empty(check)`.
- Gọi `settle()` một lần nữa ngay khi phát xong, phòng trường hợp mọi bản ghi đã về trước đó.
- Thêm chốt `done.c` đúng kiểu các test lân cận.
- Tách phần debounce thành `settle()` để hai nơi dùng chung; giữ `sub = this` để `sub.off()` vẫn huỷ đăng ký như cũ.

## Kiểm chứng

Mô phỏng đúng tình huống runner chậm — phát 3 bản ghi, im lặng 30ms (quá cửa sổ 9ms), rồi một bản ghi đến muộn:

```
logic CŨ  → done() được gọi 2 lần   ← đúng lỗi Windows CI
logic MỚI → done() được gọi 1 lần
```

Chạy lại test 40 lần liên tiếp: sạch. Toàn suite: xanh.

Lưu ý: test này chưa bao giờ đỏ ở local (60/60 sạch trước khi sửa), nên bằng chứng cho bản sửa là mô phỏng ở trên chứ không phải "hết đỏ ở local". Nguyên nhân khiến bản ghi về muộn thì #38 đã xử lý một phần.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
