### PR TITLE
test: record when each emission landed in the mutate-node map tests

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -1141,10 +1141,16 @@ describe("ZEN", function () {
           "u/m/mutate/n",
           function () {
             var check = {},
-              count = {};
+              count = {},
+              t0 = +new Date(),
+              seen = []; // every emission, with when it landed
             // This only ever fails on Windows CI, as a bare 9s timeout that
             // says nothing about which of the four expected emissions never
             // arrived. Report the collected state just before mocha gives up.
+            // The first round of this told us the missing ones are the
+            // *initial* values, not the late one, so also record the order and
+            // timing -- that says whether the initial load never delivered or
+            // was delivered and dropped.
             var diag = setTimeout(function () {
               console.log(
                 "DIAG uncached synchronous map on mutate node: counts=" +
@@ -1158,7 +1164,9 @@ describe("ZEN", function () {
                     ),
                   ) +
                   " done.last=" +
-                  !!done.last,
+                  !!done.last +
+                  " timeline=" +
+                  JSON.stringify(seen),
               );
             }, 8000);
             zen
@@ -1166,6 +1174,7 @@ describe("ZEN", function () {
               .map()
               .get("name")
               .get(function (v, f) {
+                seen.push(String(v) + "@" + (+new Date() - t0) + "ms");
                 check[v] = f;
                 count[v] = (count[v] || 0) + 1;
                 //console.log("************", f,v);
@@ -1226,9 +1235,12 @@ describe("ZEN", function () {
           "u/m/mutate/n/u",
           function () {
             var check = {},
-              count = {};
+              count = {},
+              t0 = +new Date(),
+              seen = [];
             // Same story as the sibling test above: Windows-only, and the bare
-            // timeout hides which emission went missing. Say so.
+            // timeout hides which emission went missing. Say so, with the order
+            // and timing of what did arrive.
             var diag = setTimeout(function () {
               console.log(
                 "DIAG uncached synchronous map on mutate node uncached: counts=" +
@@ -1240,13 +1252,16 @@ describe("ZEN", function () {
                     }),
                   ) +
                   " done.last=" +
-                  !!done.last,
+                  !!done.last +
+                  " timeline=" +
+                  JSON.stringify(seen),
               );
             }, 8000);
             zen
               .get("u/m/mutate/n/u")
               .map()
               .on(function (v, f) {
+                seen.push(String(v && v.name) + "@" + (+new Date() - t0) + "ms");
                 check[v.name] = f;
                 count[v.name] = (count[v.name] || 0) + 1;
                 if (check.Alice && check.Bob && check["Alice Zzxyz"]) {


### PR DESCRIPTION
Làm dày log chẩn đoán cho hai test map flaky. **Vẫn là chẩn đoán, không phải bản sửa** — và lần này là cố ý.

## Vòng chẩn đoán trước đã trả công

Log thêm ở #41 khai ra ngay ở lần đỏ Windows đầu tiên:

```
counts={"Alice Zzxyz":1}  missing=["Alice","Bob","undefined"]  done.last=true
```

Và nó **lật ngược giả định đang dùng**: test không thiếu emission **muộn**, nó thiếu emission **đầu**. Subscription vẫn sống — nó nhận được giá trị ghi lúc +300ms — chỉ lần nạp đầu là không tới nơi.

## Vì sao cần thêm timeline

Chỉ có số đếm thì không phân biệt được hai khả năng khác hẳn nhau:

- emission đầu **không bao giờ tới**, hay
- nó **tới muộn**, sau khi chốt đã kiểm xong.

Nên ghi thêm thứ tự và mốc thời gian. Lần chạy lành trông thế này:

```
timeline=["Bob@2ms","Alice@4ms","undefined@304ms","Alice Zzxyz@304ms"]
```

Cặp đầu về trong 2-4ms, cặp sau về lúc 304ms đúng theo cú ghi +300ms. Lần đỏ tới sẽ nói thẳng cặp 2-4ms là **muộn** hay **vắng**.

## Vì sao chưa sửa

Tôi đã thử tái hiện ở local, sao đúng hình dạng test — kể cả cú ghi cạnh tranh, quét ba mốc 300ms / 60ms / 10ms:

```
0/36 vòng bắt được lỗi
```

Không có vòng phản hồi thì vá là vá mù. Ở lỗi `once()` vừa sửa (#42), chính kiểu vá mù đó đã tốn của tôi **sáu lần trượt liên tiếp**; chỉ khi có test tái hiện trong 32 giây mới lần ra được gốc. Tôi không lặp lại sai lầm đó ở đây.

## Kiểm chứng

- `test:core`: **143 passing, 0 failing**
- Đã xác nhận timeline **thật sự in ra** bằng cách tạm thêm một điều kiện không bao giờ thoả vào chốt, rồi phục hồi — diff cuối chỉ có phần thêm log.
- Chỉ sửa một file test, không đụng mã nguồn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
