### PR TITLE
test: report node and child state when the mutate-node map tests time out

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -1166,7 +1166,18 @@ describe("ZEN", function () {
                   " done.last=" +
                   !!done.last +
                   " timeline=" +
-                  JSON.stringify(seen),
+                  JSON.stringify(seen) +
+                  // Separates "the node never loaded" from "it loaded and the
+                  // per-child name reads never delivered" -- the timeline alone
+                  // cannot tell those apart.
+                  " node=" +
+                  JSON.stringify(
+                    Object.keys((zen.get("u/m/mutate/n")._ || {}).put || {}),
+                  ) +
+                  " children=" +
+                  JSON.stringify(
+                    Object.keys((zen.get("u/m/mutate/n")._ || {}).next || {}),
+                  ),
               );
             }, 8000);
             zen
@@ -1254,7 +1265,15 @@ describe("ZEN", function () {
                   " done.last=" +
                   !!done.last +
                   " timeline=" +
-                  JSON.stringify(seen),
+                  JSON.stringify(seen) +
+                  " node=" +
+                  JSON.stringify(
+                    Object.keys((zen.get("u/m/mutate/n/u")._ || {}).put || {}),
+                  ) +
+                  " children=" +
+                  JSON.stringify(
+                    Object.keys((zen.get("u/m/mutate/n/u")._ || {}).next || {}),
+                  ),
               );
             }, 8000);
             zen


### PR DESCRIPTION
Vòng chẩn đoán thứ ba cho flaky map. **Vẫn chưa phải bản sửa** — và tôi giải thích rõ vì sao chưa.

## Hai vòng trước đã thu hẹp rất nhiều

Timeline thêm ở #43 cho hai mẫu Windows **giống nhau đến 1ms**:

```
mẫu 1:  timeline=["Alice Zzxyz@316ms"]
mẫu 2:  timeline=["Alice Zzxyz@317ms"]
lành:   timeline=["Bob@2ms","Alice@3ms","undefined@304ms","Alice Zzxyz@304ms"]
```

Không có gì trong ~316ms đầu, rồi đúng một giá trị — và giá trị đó đến từ **cú ghi**, không phải từ dữ liệu đã có sẵn. Độ lệch 1ms qua hai mẫu là lập luận mạnh chống lại giả thuyết "đua ngẫu nhiên": đua thật thì thời điểm phải tản mát. Cái này giống một **điều kiện nhị phân**.

## Vòng này thêm gì

Timeline vẫn chưa phân biệt được **tầng nào** đánh mất dữ liệu:

- `map()` không liệt kê được con nào, hay
- liệt kê đủ nhưng **lượt đọc `name` của từng con không giao**?

Hai khả năng này cần hai bản sửa hoàn toàn khác nhau. Nên ghi thêm trạng thái node và danh sách con. Lần chạy lành:

```
node=["_","alice","bob"]  children=["alice","bob"]
```

Lần đỏ tới sẽ nói thẳng:
- `node=[]` → node chưa bao giờ tới được chuỗi
- `node` đầy đủ nhưng timeline rỗng → node có, lượt đọc từng con không giao

## Một giả thuyết đã bị loại trong vòng này

Tôi tìm thấy một hazard thật trong `get.js` và **tái hiện được theo ý muốn**: `zen.get("a/b/c")` âm thầm biến thành duyệt đường dẫn lồng thay vì soul, khi soul chưa nằm trong `root.graph`. Cùng một lời gọi, hai kết quả khác nhau tuỳ trạng thái nạp:

```
chưa tạo đoạn nào     → soul="u/m/mutate/n"    ✅
tạo đủ mọi đoạn       → soul=undefined has="n" ❌ và map() liệt kê được []
tạo đủ + soul có sẵn  → soul="u/m/mutate/n"    ✅
```

Nó khớp hoàn hảo với triệu chứng, kể cả chi tiết "chỉ nghe thấy giá trị được ghi". **Nhưng kiểm tiền đề thì loại được nó:** nhánh đó đòi chuỗi lồng cho **mọi đoạn** đường, trong khi các test chỉ tạo khoá nguyên chuỗi:

```
khoá trong root.next: ["u/m","u/m/p","u/m/p/n","u/m/mutate","u/m/mutate/n","u/m/mutate/n/u"]
có root.next["u"]? KHÔNG → bẫy không kích hoạt được
```

Hazard đó là lỗi thật và đáng mở issue riêng, nhưng **không phải lỗi này**. Tôi suýt viết test và vá cho nó rồi báo là đã xong.

## Kiểm chứng

- `test:core`: **143 passing, 0 failing**
- Đã xác nhận trường mới **thật sự in ra** bằng cách tạm thêm điều kiện không bao giờ thoả vào chốt, rồi phục hồi
- Chỉ sửa một file test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
