### PR TITLE
test: record what the store answered when the mutate-node map test times out

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -1143,7 +1143,29 @@ describe("ZEN", function () {
             var check = {},
               count = {},
               t0 = +new Date(),
-              seen = []; // every emission, with when it landed
+              seen = [], // every emission, with when it landed
+              storeLog = [],
+              _opt = zen._.opt || {},
+              _store = _opt.store,
+              _get = _store && _store.get;
+            // The premise still to test: does the storage layer answer this
+            // read empty on the runs that fail? Everything downstream of an
+            // empty answer is understood; whether it happens is not.
+            if (_get) {
+              _store.get = function (file, cb) {
+                return _get.call(_store, file, function (e, d) {
+                  storeLog.push(
+                    String(file).slice(-20) + (d ? ":" + d.length + "b" : ":EMPTY"),
+                  );
+                  cb(e, d);
+                });
+              };
+            }
+            var unwrap = function () {
+              if (_get) {
+                _store.get = _get;
+              }
+            };
             // This only ever fails on Windows CI, as a bare 9s timeout that
             // says nothing about which of the four expected emissions never
             // arrived. Report the collected state just before mocha gives up.
@@ -1177,8 +1199,11 @@ describe("ZEN", function () {
                   " children=" +
                   JSON.stringify(
                     Object.keys((zen.get("u/m/mutate/n")._ || {}).next || {}),
-                  ),
+                  ) +
+                  " store=" +
+                  JSON.stringify(storeLog.slice(-10)),
               );
+              unwrap();
             }, 8000);
             zen
               .get("u/m/mutate/n")
@@ -1198,6 +1223,7 @@ describe("ZEN", function () {
                   clearTimeout(done.to);
                   done.to = setTimeout(function () {
                     clearTimeout(diag);
+                    unwrap();
                     expect(done.last).to.be.ok();
                     expect(check["Alice Aabca"]).to.not.be.ok();
                     expect(count.Alice).to.be(1);


### PR DESCRIPTION
Vòng chẩn đoán thứ tư — và là vòng cuối cần thiết, vì nó chỉ còn một câu hỏi **nhị phân**.

## Ba vòng trước đã dồn tới đâu

Vòng #44 chứng minh node **không bao giờ được nạp**:

```
đỏ    node=["_","alice"]        children=["alice"]
lành  node=["_","alice","bob"]  children=["alice","bob"]
```

`bob` chỉ tồn tại trên đĩa và không ai ghi đè, nên việc nó vắng mặt chứng minh lượt nạp chưa từng tới nơi. `alice` có mặt **chỉ vì** cú ghi ở +300ms đặt nó vào.

## Tái hiện xác định — nhưng dựa trên một tiền đề

Ép store trả rỗng thì tái hiện **chính xác chữ ký đỏ**, 3/3 lần:

| | Windows CI | local (ép store rỗng) |
|---|---|---|
| thiếu | `["Alice","Bob","undefined"]` | `["Alice","Bob","undefined"]` |
| node | `["_","alice"]` | `["_","alice"]` |
| children | `["alice"]` | `["alice"]` |
| timeline | `["Alice Zzxyz@316ms"]` | `["Alice Zzxyz@313ms"]` |

Khớp cả bốn trường. Nhưng **"store trả rỗng" là thứ tôi tự ép, không phải thứ tôi quan sát được** — trên máy này store trả đủ dữ liệu.

Đối chiếu: ép store **chậm** (200/500/900ms) cũng làm test đỏ, nhưng chữ ký **khác hẳn** (`node` vẫn đủ, chỉ thiếu `Alice`). Nếu chỉ nhìn "test đỏ rồi" thì đã kết luận nhầm — chữ ký mới là thứ phân biệt.

## Vì sao chưa sửa

Bản sửa mà tiền đề này gợi ý là **hỏi lại sau câu trả lời rỗng**. Đó là đổi zen từ mô hình đẩy sang có phần hỏi vòng, và làm mọi node thật sự không tồn tại phải chịu thêm một lượt hỏi. Quá nhiều để đánh đổi cho một giả định.

Trong đợt này tôi đã sáu lần vá lõi theo giả thuyết và sai cả sáu lần; chỉ khi có tái hiện thật mới lần ra gốc của #42. Tôi không muốn lần thứ bảy là một thay đổi ngữ nghĩa mà tôi chưa chứng minh được là cần.

## Vòng này ghi lại gì

Store trả gì, cho đúng test đó. Lần đỏ tới sẽ dứt điểm tranh luận:

- có `:EMPTY` cho file chứa `u/m/mutate/n` → tiền đề **đúng**, bản sửa hỏi-lại chính đáng, và tôi đã có sẵn test bất biến lẫn tái hiện xác định
- có số byte → tiền đề **sai**, mất mát nằm giữa store và chuỗi, đào chỗ khác

Lần chạy lành đọc như sau:

```
store=["m%2Fmutate%2Fn%1Bbob:633b","!:721b","2Falice%2Fpet%1Bname:673b",...]
```

Wrapper chỉ cài trong đúng test này và **gỡ ở cả hai đường** — thành công lẫn timeout.

## Kiểm chứng

- `test:core`: **143 passing, 0 failing**
- Đã xác nhận trường mới in ra thật, bằng cách tạm thêm điều kiện không bao giờ thoả rồi phục hồi
- Chỉ sửa một file test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
