### PR TITLE
test: record whether the read was ever issued for the flaky map node

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -1299,13 +1299,20 @@ describe("ZEN", function () {
                   " gate=" +
                   gate +
                   " rad=" +
-                  JSON.stringify(radLog.slice(0, 8)) +
+                  JSON.stringify(radLog.slice(0, 14)) +
                   " radN=" +
                   _Rn +
                   "/" +
                   !!_read +
                   " chungRad=" +
                   sameR +
+                  // When statedisk's put said "done", against when radisk
+                  // actually saved. The red walk puts the read at 1ms and the
+                  // first save of this soul at 2ms, which would mean the ack
+                  // outran the write it was acking.
+                  " ackO=" +
+                  (t0 - t00) +
+                  "ms" +
                   " dir0=" +
                   JSON.stringify(dir0) +
                   " dir8=" +

--- a/test/common.js
+++ b/test/common.js
@@ -1201,10 +1201,39 @@ describe("ZEN", function () {
                     Object.keys((zen.get("u/m/mutate/n")._ || {}).next || {}),
                   ) +
                   " store=" +
-                  JSON.stringify(storeLog.slice(-10)),
+                  JSON.stringify(storeLog.slice(-10)) +
+                  " gets=" +
+                  JSON.stringify(gets) +
+                  " gate=" +
+                  gate,
               );
               unwrap();
             }, 8000);
+            // The store log alone cannot say whether the read ever happened: a
+            // node still held in radisk's memory is served with no store call
+            // at all, and locally that is the *healthy* path. So watch the GET
+            // itself. Alongside it, record the gate in chain.js that can
+            // suppress the GET -- an earlier ask for the full node plus data
+            // already on it makes chain.js send the cache down and return
+            // without asking storage again.
+            var gets = [];
+            zen._.on("get", function (msg) {
+              this.to.next(msg);
+              if ("u/m/mutate/n" === (((msg || "").get || "")["#"] || "")) {
+                gets.push(
+                  (msg.get["."] || "*") + "@" + (+new Date() - t0) + "ms",
+                );
+              }
+            });
+            var _b = zen.get("u/m/mutate/n")._ || {},
+              _ctl = zen.get("diag/never/asked")._ || {}, // never touched
+              gate =
+                "askTruoc=" +
+                !!(_b.ask && _b.ask[""]) +
+                " coPut=" +
+                (undefined !== _b.put) +
+                " doiChung=" +
+                !!(_ctl.ask && _ctl.ask[""]);
             zen
               .get("u/m/mutate/n")
               .map()

--- a/test/common.js
+++ b/test/common.js
@@ -2,6 +2,8 @@
 import zenbase from "../zen.js";
 import "../lib/store.js";
 import "../lib/rfs.js";
+import __radisk from "../lib/radisk.js"; // same module lib/store.js builds on,
+// so __radisk.has holds the very instance serving these tests.
 import "./rad/rad.js";
 import fs from "fs";
 import fsrm from "../lib/fsrm.js";
@@ -1147,10 +1149,25 @@ describe("ZEN", function () {
               storeLog = [],
               _opt = zen._.opt || {},
               _store = _opt.store,
-              _get = _store && _store.get;
-            // The premise still to test: does the storage layer answer this
-            // read empty on the runs that fail? Everything downstream of an
-            // empty answer is understood; whether it happens is not.
+              _get = _store && _store.get,
+              radLog = [],
+              radPush = function (s) {
+                // the per-child reads repeat the same line; keep the walk legible
+                if (radLog[radLog.length - 1] !== s) {
+                  radLog.push(s);
+                }
+              },
+              _esc = String.fromCharCode(27),
+              // Radisk keys its instances by the *resolved* opt.file, and it
+              // resolves opt.file in place, so this is the same string.
+              _R = (__radisk.has || {})[_opt.file],
+              _Rn = Object.keys(__radisk.has || {}).length,
+              _read = _R && _R.read,
+              _find = _R && _R.find;
+            // The store log records which files were touched. It does not say
+            // whether the node was found in them -- radisk walks a range of
+            // files and reports nothing if the key is in none of them, which
+            // looks identical from outside to never having read at all.
             if (_get) {
               _store.get = function (file, cb) {
                 return _get.call(_store, file, function (e, d) {
@@ -1161,7 +1178,50 @@ describe("ZEN", function () {
                 });
               };
             }
+            // Follow the range walk for this soul: which file the directory
+            // sends us to, and whether each chunk of the walk yields data.
+            if (_read) {
+              var _wfind = function (key, cb) {
+                if (0 !== String(key).indexOf("u/m/mutate/n")) {
+                  return _find.apply(_R, arguments);
+                }
+                return _find.call(_R, key, function (file) {
+                  radPush("file=" + String(file).slice(-18));
+                  return cb.apply(this, arguments);
+                });
+              };
+              // r.find carries .add and .bad; radisk calls them by name.
+              Object.keys(_find).forEach(function (k) {
+                _wfind[k] = _find[k];
+              });
+              _R.find = _wfind;
+              _R.read = function (key, cb, o, DBG) {
+                if (0 !== String(key).indexOf("u/m/mutate/n")) {
+                  return _read.apply(_R, arguments);
+                }
+                return _read.call(
+                  _R,
+                  key,
+                  function (err, data, oo) {
+                    radPush(
+                      "chunk" +
+                        ((oo || {}).chunks || 0) +
+                        (data ? "=co" : "=rong") +
+                        " tiep=" +
+                        String((oo || {}).next || "het").slice(-14),
+                    );
+                    return cb.apply(this, arguments);
+                  },
+                  o,
+                  DBG,
+                );
+              };
+            }
             var unwrap = function () {
+              if (_read) {
+                _R.read = _read;
+                _R.find = _find;
+              }
               if (_get) {
                 _store.get = _get;
               }
@@ -1205,8 +1265,36 @@ describe("ZEN", function () {
                   " gets=" +
                   JSON.stringify(gets) +
                   " gate=" +
-                  gate,
+                  gate +
+                  " rad=" +
+                  JSON.stringify(radLog.slice(0, 8)) +
+                  " radN=" +
+                  _Rn +
+                  "/" +
+                  !!_read,
               );
+              // Is the node actually in the file the directory points at? This
+              // separates "written somewhere the directory does not know about"
+              // from "in the right file, and radisk still did not return it".
+              // Async, so it lands as its own line a moment later.
+              if (_find && _get) {
+                _find.call(_R, "u/m/mutate/n" + _esc, function (file) {
+                  _get.call(_store, file, function (e, d) {
+                    console.log(
+                      "DIAG uncached synchronous map on mutate node do file: file=" +
+                        String(file).slice(-18) +
+                        " co_soul=" +
+                        (String(d || "").indexOf("u/m/mutate/n") >= 0) +
+                        " co_bob=" +
+                        (String(d || "").indexOf("Bob") >= 0) +
+                        " bytes=" +
+                        String(d || "").length,
+                    );
+                    unwrap();
+                  });
+                });
+                return;
+              }
               unwrap();
             }, 8000);
             // The store log alone cannot say whether the read ever happened: a

--- a/test/common.js
+++ b/test/common.js
@@ -1151,6 +1151,7 @@ describe("ZEN", function () {
               _store = _opt.store,
               _get = _store && _store.get,
               radLog = [],
+              dir0 = null,
               radPush = function (s) {
                 // the per-child reads repeat the same line; keep the walk legible
                 if (radLog[radLog.length - 1] !== s) {
@@ -1163,7 +1164,29 @@ describe("ZEN", function () {
               _R = (__radisk.has || {})[_opt.file],
               _Rn = Object.keys(__radisk.has || {}).length,
               _read = _R && _R.read,
-              _find = _R && _R.find;
+              _find = _R && _R.find,
+              // The directory keys around this soul. The red walk went to a
+              // file far to the left of the node and then jumped clean over
+              // `u/m/bob<esc>pet`, the file that actually holds it -- so the
+              // question is whether the directory was missing that entry at
+              // the moment of the read and gained it later.
+              dirNear = function () {
+                var out = [];
+                _R &&
+                  _R.list &&
+                  __radisk.Radix.map(
+                    _R.list,
+                    function (v, k) {
+                      v && out.push(String(k).slice(0, 22));
+                    },
+                    { start: "u/m", end: "u/n" },
+                  );
+                return out;
+              },
+              // Writer and reader must be the same Radisk to share a directory.
+              // Two instances over one folder would each hold their own, and
+              // the reader's would never learn of files the writer just made.
+              sameR = _R === (__radisk.has || {})[(goff._.opt || {}).file];
             // The store log records which files were touched. It does not say
             // whether the node was found in them -- radisk walks a range of
             // files and reports nothing if the key is in none of them, which
@@ -1187,6 +1210,9 @@ describe("ZEN", function () {
                 }
                 return _find.call(_R, key, function (file) {
                   radPush("file=" + String(file).slice(-18));
+                  // r.list is bound by now, so this is the directory as the
+                  // very first read of this soul saw it.
+                  dir0 || (dir0 = dirNear());
                   return cb.apply(this, arguments);
                 });
               };
@@ -1271,7 +1297,13 @@ describe("ZEN", function () {
                   " radN=" +
                   _Rn +
                   "/" +
-                  !!_read,
+                  !!_read +
+                  " chungRad=" +
+                  sameR +
+                  " dir0=" +
+                  JSON.stringify(dir0) +
+                  " dir8=" +
+                  JSON.stringify(dirNear()),
               );
               // Is the node actually in the file the directory points at? This
               // separates "written somewhere the directory does not know about"

--- a/test/common.js
+++ b/test/common.js
@@ -1126,6 +1126,121 @@ describe("ZEN", function () {
       });
 
       it("uncached synchronous map on mutate node", function (done) {
+        // Installed *before* statedisk writes, so the write's own directory
+        // lookup is captured too. Last round could only see the read's, and the
+        // pair is what matters: the read went to `sabnb<esc>profile` while the
+        // directory held a single entry in the whole u/m..u/n range. Where the
+        // write put the node is the other half of that.
+        var check = {},
+          count = {},
+          t0 = 0,
+          t00 = +new Date(),
+          seen = [], // every emission, with when it landed
+          storeLog = [],
+          radLog = [],
+          dir0 = null,
+          radPush = function (s) {
+            // the per-child reads repeat one line; keep the walk legible
+            if (radLog.last === s) {
+              return;
+            }
+            radLog.last = s;
+            radLog.push(s + "@" + (+new Date() - t00) + "ms");
+          },
+          _esc = String.fromCharCode(27),
+          _opt = zen._.opt || {},
+          _store = _opt.store,
+          _get = _store && _store.get,
+          // Radisk keys its instances by the *resolved* opt.file, and it
+          // resolves opt.file in place, so this is the same string.
+          _R = (__radisk.has || {})[_opt.file],
+          _Rn = Object.keys(__radisk.has || {}).length,
+          _read = _R && _R.read,
+          _find = _R && _R.find,
+          _save = _R && _R.save,
+          // The directory keys around this soul.
+          dirNear = function () {
+            var out = [];
+            _R &&
+              _R.list &&
+              __radisk.Radix.map(
+                _R.list,
+                function (v, k) {
+                  v && out.push(String(k).slice(0, 22));
+                },
+                { start: "u/m", end: "u/n" },
+              );
+            return out;
+          },
+          // Writer and reader must be the same Radisk to share a directory.
+          sameR = _R === (__radisk.has || {})[(goff._.opt || {}).file];
+        if (_get) {
+          _store.get = function (file, cb) {
+            return _get.call(_store, file, function (e, d) {
+              storeLog.push(
+                String(file).slice(-20) + (d ? ":" + d.length + "b" : ":EMPTY"),
+              );
+              cb(e, d);
+            });
+          };
+        }
+        // Follow every directory lookup, write and range walk for this soul.
+        if (_read) {
+          var _wfind = function (key, cb) {
+            if (0 !== String(key).indexOf("u/m/mutate/n")) {
+              return _find.apply(_R, arguments);
+            }
+            return _find.call(_R, key, function (file) {
+              radPush("file=" + String(file).slice(-18));
+              // r.list is bound by now, so this is the directory as the very
+              // first lookup for this soul saw it.
+              dir0 || (dir0 = dirNear());
+              return cb.apply(this, arguments);
+            });
+          };
+          // r.find carries .add and .bad; radisk calls them by name.
+          Object.keys(_find).forEach(function (k) {
+            _wfind[k] = _find[k];
+          });
+          _R.find = _wfind;
+          _R.save = function (key) {
+            if (0 === String(key).indexOf("u/m/mutate/n")) {
+              radPush("ghi " + String(key).slice(12, 22));
+            }
+            return _save.apply(_R, arguments);
+          };
+          _R.read = function (key, cb, o, DBG) {
+            if (0 !== String(key).indexOf("u/m/mutate/n")) {
+              return _read.apply(_R, arguments);
+            }
+            return _read.call(
+              _R,
+              key,
+              function (err, data, oo) {
+                radPush(
+                  "chunk" +
+                    ((oo || {}).chunks || 0) +
+                    (data ? "=co" : "=rong") +
+                    " tiep=" +
+                    String((oo || {}).next || "het").slice(-14),
+                );
+                return cb.apply(this, arguments);
+              },
+              o,
+              DBG,
+            );
+          };
+        }
+        var unwrap = function () {
+          if (_read) {
+            _R.read = _read;
+            _R.find = _find;
+            _R.save = _save;
+          }
+          if (_get) {
+            _store.get = _get;
+          }
+        };
         Zen.statedisk(
           {
             alice: {
@@ -1142,116 +1257,7 @@ describe("ZEN", function () {
           },
           "u/m/mutate/n",
           function () {
-            var check = {},
-              count = {},
-              t0 = +new Date(),
-              seen = [], // every emission, with when it landed
-              storeLog = [],
-              _opt = zen._.opt || {},
-              _store = _opt.store,
-              _get = _store && _store.get,
-              radLog = [],
-              dir0 = null,
-              radPush = function (s) {
-                // the per-child reads repeat the same line; keep the walk legible
-                if (radLog[radLog.length - 1] !== s) {
-                  radLog.push(s);
-                }
-              },
-              _esc = String.fromCharCode(27),
-              // Radisk keys its instances by the *resolved* opt.file, and it
-              // resolves opt.file in place, so this is the same string.
-              _R = (__radisk.has || {})[_opt.file],
-              _Rn = Object.keys(__radisk.has || {}).length,
-              _read = _R && _R.read,
-              _find = _R && _R.find,
-              // The directory keys around this soul. The red walk went to a
-              // file far to the left of the node and then jumped clean over
-              // `u/m/bob<esc>pet`, the file that actually holds it -- so the
-              // question is whether the directory was missing that entry at
-              // the moment of the read and gained it later.
-              dirNear = function () {
-                var out = [];
-                _R &&
-                  _R.list &&
-                  __radisk.Radix.map(
-                    _R.list,
-                    function (v, k) {
-                      v && out.push(String(k).slice(0, 22));
-                    },
-                    { start: "u/m", end: "u/n" },
-                  );
-                return out;
-              },
-              // Writer and reader must be the same Radisk to share a directory.
-              // Two instances over one folder would each hold their own, and
-              // the reader's would never learn of files the writer just made.
-              sameR = _R === (__radisk.has || {})[(goff._.opt || {}).file];
-            // The store log records which files were touched. It does not say
-            // whether the node was found in them -- radisk walks a range of
-            // files and reports nothing if the key is in none of them, which
-            // looks identical from outside to never having read at all.
-            if (_get) {
-              _store.get = function (file, cb) {
-                return _get.call(_store, file, function (e, d) {
-                  storeLog.push(
-                    String(file).slice(-20) + (d ? ":" + d.length + "b" : ":EMPTY"),
-                  );
-                  cb(e, d);
-                });
-              };
-            }
-            // Follow the range walk for this soul: which file the directory
-            // sends us to, and whether each chunk of the walk yields data.
-            if (_read) {
-              var _wfind = function (key, cb) {
-                if (0 !== String(key).indexOf("u/m/mutate/n")) {
-                  return _find.apply(_R, arguments);
-                }
-                return _find.call(_R, key, function (file) {
-                  radPush("file=" + String(file).slice(-18));
-                  // r.list is bound by now, so this is the directory as the
-                  // very first read of this soul saw it.
-                  dir0 || (dir0 = dirNear());
-                  return cb.apply(this, arguments);
-                });
-              };
-              // r.find carries .add and .bad; radisk calls them by name.
-              Object.keys(_find).forEach(function (k) {
-                _wfind[k] = _find[k];
-              });
-              _R.find = _wfind;
-              _R.read = function (key, cb, o, DBG) {
-                if (0 !== String(key).indexOf("u/m/mutate/n")) {
-                  return _read.apply(_R, arguments);
-                }
-                return _read.call(
-                  _R,
-                  key,
-                  function (err, data, oo) {
-                    radPush(
-                      "chunk" +
-                        ((oo || {}).chunks || 0) +
-                        (data ? "=co" : "=rong") +
-                        " tiep=" +
-                        String((oo || {}).next || "het").slice(-14),
-                    );
-                    return cb.apply(this, arguments);
-                  },
-                  o,
-                  DBG,
-                );
-              };
-            }
-            var unwrap = function () {
-              if (_read) {
-                _R.read = _read;
-                _R.find = _find;
-              }
-              if (_get) {
-                _store.get = _get;
-              }
-            };
+            t0 = +new Date();
             // This only ever fails on Windows CI, as a bare 9s timeout that
             // says nothing about which of the four expected emissions never
             // arrived. Report the collected state just before mocha gives up.


### PR DESCRIPTION
Chẩn đoán, không phải bản sửa. Vòng trước trả lời xong câu hỏi của nó và **giết luôn tiền đề** đứng sau nó.

## Điều vòng trước thực sự nói

```
đỏ:   store=["u%2Fm%2Fbob%1Bpet:962b", "Fp%2Falice%2Fpet%1Ba:613b"]
lành: store=["m%2Fmutate%2Fn%1Bbob:633b", …]
```

Lần đỏ, store **không hề bị hỏi** file của node này. Trông rất đáng buộc tội — cho tới khi tôi đo đúng phép đo đó ở local:

```
thay = ["Alice@3ms","Bob@4ms"]      ← cả hai con về đủ, 3ms
doc  = []                            ← store KHÔNG được hỏi file đó
```

`zen` và `goff` cùng `opt.file`, mà `Radisk.has` đánh khoá theo `opt.file`, nên **hai instance dùng chung một Radisk**. Node vừa ghi còn nằm trong `r.disk` — đọc được phục vụ thẳng từ bộ nhớ, **không cần lượt store nào**. Đó là đường **lành**.

Nên "store không được hỏi" **không phân biệt** được:
- **A** — chưa từng có ai hỏi, hay
- **B** — radisk đã trả lời từ bộ nhớ (và trả sai/rỗng).

Tiền đề cũ của tôi ("store trả rỗng rồi không ai hỏi lại") thì đã bị bác bỏ dứt điểm: không có `:EMPTY` nào cả.

## Phép đo lần này

Nhìn thẳng vào **lượt GET**, kèm trạng thái của đúng một cổng trong `chain.js:60-67` có thể nuốt lượt GET đó:

```js
tmp = back.ask && back.ask[""];        // đã hỏi node đầy đủ chưa
(back.ask || (back.ask = {}))[""] = back;
if (u !== back.put) {                  // đã có sẵn dữ liệu
  back.on("in", back);                 // đẩy cache xuống chuỗi
  if (tmp) { return; }                 // và KHÔNG hỏi lại nữa
}
```

Chữ ký đỏ có `node=["_","alice"]` — tức `back.put` **không rỗng**, nên vế `u !== back.put` thoả. Chỉ còn thiếu `back.ask[""]`.

## Đối chứng lành, đo được ở local

```
gets=["*@0ms"]  gate=askTruoc=false coPut=false doiChung=false
```

Một lượt GET toàn node lúc 0ms, cổng mở. `doiChung` là một soul không bao giờ bị đụng tới — nếu nó ra `true` thì **máy đo hỏng**, không phải code. Tôi đã ăn ba lần đọc sai dữ liệu của chính mình ở đợt trước vì thiếu đúng loại dòng này.

## Đọc kết quả

| dấu hiệu trên lần đỏ | kết luận |
|---|---|
| `gets=[]` + `askTruoc=true coPut=true` | chuỗi đã nuốt lượt đọc → sửa ở `chain.js` |
| `gets=["*@0ms"]` | lượt đọc có phát ra → mất mát nằm dưới, đào radisk |
| `doiChung=true` | máy đo hỏng, bỏ mẫu |

Test vẫn xanh ở local (2/2); phần thêm chỉ chạy trong nhánh báo lỗi.

## Chưa khép

Chưa biết vì sao chỉ Windows. Và đây là **vòng đo thứ năm** — tôi vẫn chưa tái hiện được lỗi ở local, nên mọi kết luận đến giờ đều dựa vào mẫu CI chứ không phải một bản tái hiện điều khiển được.

🤖 Generated with [Claude Code](https://claude.com/claude-code)