### PR TITLE
test: wire up read-after-write, and make it cheap enough to keep

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:core": "npm run clean && cross-env GUN_TEST_TMP=1 ZEN_SILENCE_TEST_WARNINGS=1 node --import ./test/loaders/register-zen-minified.mjs ./node_modules/mocha/bin/_mocha --exit test/abc.js test/rad/rad.js test/rad/flush-read.js test/rad/invariants.js test/radix.js test/zen.js",
     "test:mesh": "npm run clean && cross-env GUN_TEST_TMP=1 ZEN_TEST=1 node --import ./test/loaders/register-zen-minified.mjs ./node_modules/mocha/bin/_mocha --exit test/mesh/dam.js --timeout 10000",
     "test:dht": "cross-env GUN_TEST_TMP=1 ZEN_TEST=1 node --import ./test/loaders/register-zen-minified.mjs ./node_modules/mocha/bin/_mocha --exit test/dht/kbucket.js --timeout 10000",
-    "test:zen:unit": "npm run clean && cross-env GUN_TEST_TMP=1 ZEN_TEST=1 node --import ./test/loaders/register-zen-minified.mjs ./node_modules/mocha/bin/_mocha --exit test/zen/instance.js test/zen/nostore.js test/zen/concurrent-writes.js test/zen/bootstrap.js test/zen/secp256k1.js test/zen/crypto.js test/zen/multicurve.js test/zen/certify.js test/zen/recover.js test/zen/push.js test/zen/port.js test/zen/status.js test/mesh/dam.js",
+    "test:zen:unit": "npm run clean && cross-env GUN_TEST_TMP=1 ZEN_TEST=1 node --import ./test/loaders/register-zen-minified.mjs ./node_modules/mocha/bin/_mocha --exit test/zen/instance.js test/zen/nostore.js test/zen/concurrent-writes.js test/zen/read-after-write.js test/zen/bootstrap.js test/zen/secp256k1.js test/zen/crypto.js test/zen/multicurve.js test/zen/certify.js test/zen/recover.js test/zen/push.js test/zen/port.js test/zen/status.js test/mesh/dam.js",
     "test:zen": "npm run build:zen && npm run test:zen:unit",
     "e2e": "mocha e2e/distributed.js",
     "docker": "hooks/build",

--- a/test/zen/read-after-write.js
+++ b/test/zen/read-after-write.js
@@ -79,12 +79,23 @@ describe("read after write", function () {
       setTimeout(r, 3000);
     });
 
+    // Batched. once() waits out its own 99ms debounce before firing, so two
+    // hundred reads one after another cost twenty seconds of nothing but that
+    // wait. Reading them together is also closer to the shape that broke:
+    // reads landing while writes are still draining.
     var miss = [];
-    for (var j = 0; j < N; j++) {
-      var v = await read(zen.get(root).get("c").get("k" + j));
-      if (!v || v.o !== j) {
-        miss.push(j);
-      }
+    for (var b = 0; b < N; b += 25) {
+      var got = await Promise.all(
+        Array.from({ length: Math.min(25, N - b) }, function (_, k) {
+          return read(zen.get(root).get("c").get("k" + (b + k)));
+        }),
+      );
+      got.forEach(function (v, k) {
+        var j = b + k;
+        if (!v || v.o !== j) {
+          miss.push(j);
+        }
+      });
     }
     assert.strictEqual(
       miss.length,


### PR DESCRIPTION
`test/zen/read-after-write.js` được viết để tái hiện **#42** — `once()` không bao giờ nổ với lượt đọc đi qua liên kết. Nó làm xong việc, nhưng **chưa từng được thêm vào script npm nào**, nên nằm im trong repo không ai chạy.

## Vì sao trước đây dễ bỏ qua

Nó tốn **32 giây**. Gần như toàn bộ nằm ở phần **đọc**: `once()` chờ hết nhịp 99ms của chính nó rồi mới nổ, nên hai trăm lượt đọc nối đuôi nhau là **hai mươi giây chỉ để chờ**.

Gộp lại thì cùng hai trăm lượt đọc mất **12 giây**. Và đọc cùng lúc còn **gần với hình dạng đã gây lỗi hơn** — lượt đọc rơi vào lúc các cú ghi còn đang rút.

## Kiểm chứ không đoán

Gỡ `cat.repass` khỏi `src/get.js` — chính bản sửa của #42 — thì bản đã gộp **vẫn đỏ**. Nên nó không mất răng khi viết lại. Trả bản sửa về: xanh 3/3, 12 giây.

Có thử gộp cả phần **ghi**: không nhanh hơn chút nào. Ký chữ ký chưa bao giờ là chỗ nghẽn.

Toàn suite **795 passing, 0 failing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)