### PR TITLE
fix(install): write the sudoers rule even when the installer runs as root

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -342,7 +342,13 @@ configure_sudoers() {
     if [ "$SKIP_SERVICE" = "true" ]; then
         return
     fi
-    if [ "$(id -u)" -eq 0 ]; then
+    # Skip only when the *service user* is root -- then nothing it does needs a
+    # password. Running the installer under sudo is a different thing entirely:
+    # the service still runs as $REAL_USER, and that user is exactly who has to
+    # restart it afterwards. Returning early here left every sudo-installed host
+    # without the rule, so its hourly auto-update pulled new code and then died
+    # on "sudo: a password is required" at the restart, silently, forever.
+    if [ "$REAL_USER" = "root" ]; then
         return
     fi
 

--- a/script/update.sh
+++ b/script/update.sh
@@ -71,6 +71,18 @@ while [ $# -gt 0 ]; do
     esac
 done
 
+# Under `sudo` every path this script works from points at the wrong place:
+# INSTALL_DIR is "$HOME/zen", nvm lives in "$HOME/.nvm", the state stamp is
+# under "$HOME/.local/state" -- and $HOME is /root. It would look for a checkout
+# that is not there and install a launcher nobody runs. Root is only ever needed
+# for the one `systemctl restart`, which this script asks for itself.
+if [ "$(id -u)" -eq 0 ] && [ -n "${SUDO_USER:-}" ]; then
+    log_error "Run 'zen update' as ${SUDO_USER}, not with sudo."
+    log_error "It updates the checkout in that user's home; root only enters for"
+    log_error "the service restart, which this script requests on its own."
+    exit 1
+fi
+
 if [ "$(id -u)" -eq 0 ]; then
     SUDO=""
 else


### PR DESCRIPTION
Bộ tự cập nhật **chưa từng khởi động lại được service** kể từ lúc cài — âm thầm, mỗi giờ một lần.

## Triệu chứng

```
Aug 08 22:48:53 zen-update: [INFO] Running: sudo -n systemctl restart zen
Aug 08 22:48:53 sudo: x : a password is required ; COMMAND=/usr/bin/systemctl restart zen
Aug 08 22:48:53 systemd: Failed to start zen-update.service
```

Nó kéo code mới về **thành công**, rồi chết đúng ở bước restart. Nên service cứ chạy code cũ cho tới khi có người restart tay.

## Nguyên nhân

`install.sh` **có** tạo quy tắc sudo không mật khẩu cho việc quản service. Nhưng:

```sh
configure_sudoers() {
    ...
    if [ "$(id -u)" -eq 0 ]; then
        return
    fi
```

Cài bằng `sudo` là cách cài **bình thường**, và `REAL_USER` vốn đã được suy ra từ `SUDO_USER`, nên service chạy dưới tên user gọi lệnh — **đúng người mà quy tắc ấy sinh ra để phục vụ**. Bỏ qua ở đó là ngược.

Kết quả trên máy này: **không hề có** `/etc/sudoers.d/zen`.

## Bản sửa

Chỉ bỏ qua khi **chính service user là root** — lúc đó không có gì cần mật khẩu.

Kèm theo: chặn `update.sh` khi bị chạy dưới `sudo`. Mọi đường dẫn của nó đều bám `$HOME` — checkout, nvm, tệp mốc trạng thái — nên chạy bằng root là đi tìm `/root/zen` và cài launcher không ai dùng. Nó chỉ cần root cho **đúng một** `systemctl restart`, và nó tự xin lấy. Thà báo lỗi rõ còn hơn hỏng khó hiểu.

Toàn suite **795 passing, 0 failing**.

## Máy đã cài rồi thì cần một lệnh

Bản sửa này chỉ giúp lần cài sau. Máy hiện tại vẫn thiếu quy tắc, phải ghi một lần bằng tay — lệnh cụ thể nằm trong phần thảo luận.

🤖 Generated with [Claude Code](https://claude.com/claude-code)