### PR TITLE
docs: catch up with 1.0.39–1.0.44 — ephemeral storage, mailbox pattern, WsProvider, R5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 # CHANGELOG
 
+## 1.0.44 — 2026-08-09
+
+### PEN
+
+- **`R[5]` is now recovered on re-propagation, so pen souls actually propagate** (`src/pen.js`, akao#189): `penStage` verified the signature on a relayed write but left the writer register blank — `R[5]` was only truthful on the node that originated the write. Every writer-pinning policy (`eq [reg 5, pub]`) therefore failed on every *remote* peer, and the failure was silent and total: pen-soul data was acked at the relay and dropped at each subscriber, with no error anywhere. Both re-propagation paths (structured envelope and raw signed string) now recover the signer before the predicate runs; an unrecoverable signature is rejected with `PEN: cannot recover signer pub`. Remote peers are exactly where writer pinning matters most. Isolated with a repro matrix — plain soul ✓, marker key ✓, *any* pen soul ✗ — before the fix.
+
+### Storage
+
+- **Ephemeral `<?N` data is held in a real RAM store, not merely skipped** (`lib/store.js`): 1.0.41 skipped the disk but kept nothing, and a long-lived relay collects its chain cache — so ephemeral data became unservable, acked into the void and invisible to any cold reader. Ephemeral writes now live in a per-instance map with a genuine per-key expiry parsed from the marker, swept lazily on read and by an `unref()`'d 60-second timer, and **reads are served from it**. True wall-clock TTL included.
+- `test/zen/mailbox.js` gains a wire block: a remote subscriber receiving the engine's per-user slot write (blank `R[5]` used to drop it) and a cold reader catching up from the relay's RAM store. Suite: 812 passing, 39 pending, 0 failing.
+
+## 1.0.43 — 2026-08-09
+
+### Storage
+
+- **`<?N` works on KEYS, not just souls** (`lib/store.js`, `src/locstore.js`, `src/security.js`): the marker now makes a single slot of an otherwise durable node ephemeral. All three doors read it — the `forget` sync gate and both storage paths.
+- **The PEN mailbox pattern** (akao#189, documented in ch07 §7.13): one public policy soul where every participant is fenced into `key = <their recovered pub><?N` — identity from the signature, fencing from the policy, forgetting from the marker. It solves inboxes into a namespace nobody else can write to, without issuing certificates. The PEN grammar needed nothing new: `suf` pins the marker, `let`+`seg` binds the key prefix, `eq [reg 128, reg 5]` matches it against the recovered writer. New suite `test/zen/mailbox.js`.
+
+## 1.0.42 — 2026-08-09
+
+### Storage
+
+- **The ephemeral guard must not call into an undefined soul** (`lib/store.js`, `src/locstore.js`): 1.0.41 ran `soul.indexOf` on every put frame, but not every frame carries `put['#']` — and the original code only ever *concatenated* `soul`, which `undefined` survives. A method call does not: the throw inside the put handler swallowed that frame's event. akao's DB suite caught it as a branch subscriber going deaf to child writes (green on 1.0.40, red on 1.0.41, three runs each way, then bisected by pinning versions). Both doors are `typeof`-guarded now — the house truthiness lesson, one layer up.
+
+## 1.0.41 — 2026-08-09
+
+### Storage
+
+- **The lost half of `<?N` ephemeral souls is restored** (`lib/store.js`, `src/locstore.js`): the marker always had two halves. The sync gate survived the rewrite — `src/security.js`'s `forget` stage drops stale copies at ingest — but the storage half did not, so ephemeral writes went to radisk and localStorage like any other and "ephemeral" data outlived its window on every relay's disk. Ephemeral writes skip persistence entirely now, acking like memory-only mode, with the ack **deferred a tick**: an `in` fired synchronously inside the `put` event races the chain still registering its pending ack and gets swallowed. New suite `test/zen/ephemeral.js` greps the store's own bytes to prove it.
+
+## 1.0.40 — 2026-08-08
+
+### EVM chains
+
+- **`WsProvider.on(filter)` — logs subscriptions** (`lib/chains/evm.js`): an object argument is an `eth_subscribe ["logs", filter]`, ethers-parity. Filters survive reconnects *intact*: `_subHandlers` now stores `{ handler, params }` so `_resubscribeAll` replays the exact subscription rather than just its topic name.
+- **`WsProvider.on("head")` — the full enriched header**: `on("block")` keeps ethers parity and delivers a bare block number, but a consumer that stamps data with the block's real timestamp had to pay a `getBlock` round trip per block to recover what the header already carried. Both channels coexist and both re-subscribe.
+- **`WsProvider.on("reconnect")`**: fired only *after* `_resubscribeAll` completes, so a gap-healing consumer never sees fresh events land on an unhealed gap. `reconnect` and `error` registrations no longer force a connection.
+- **`destroy()` actually destroys**: the old body only closed the socket — pending calls hung to their timeout, every subscription table survived, and a dropped provider kept reconnecting as a zombie. It now rejects every pending call with `WS destroyed` and clears all state. (Found the hard way: the first draft added a *second* `destroy()` above the old one, and the later definition silently won.)
+- Driven by akao's DEX candle miner, which needed pushed swap logs, real block timestamps and a heal signal — and had been keeping a raw WebSocket alive because this surface did not exist.
+
+## 1.0.39 — 2026-08-08
+
+### Install
+
+- **The sudoers rule is written even when the installer runs as root** (#59), **`visudo` is found even though it is not on a normal user's PATH**, **the installer survives being run from a directory that no longer exists**, and **HTTPS turns itself on when `acme.sh` already holds the certificate**.
+
+### Core & storage (the read-after-write hunt, #36–#58)
+
+- **A write parked on an in-flight flush is visible while it waits** (#55, `lib/radisk.js`): a write arriving during a flush existed only in the closure that parked it — not in `r.disk`, not in the snapshot being written, not on disk. A read for that key found nothing anywhere and nothing asked again; worse, it could answer *stale* from the pre-flush snapshot. This removed the retry ladders of #52/#53 on purpose: with the cause gone they carried nothing.
+- **A blocked rename is retried instead of deleting the file it targets** (#51), **a parked write is replayed against the file it belongs to now** (#47), **a file whose name is a prefix of already-listed names is listed** (#49), and **the read/write hole during a batch flush is closed** (#40).
+- **Concurrent child-node writes no longer deadlock** (#38, `src/put.js`): `put()` resolved a child's soul with an internal GET that parked on other writes' stun lists, so N concurrent puts under one parent could all wait on each other forever. The GET only needs the soul, never the data.
+- **GETs nobody can answer are answered instead of hanging** (#36), and **`link()` learns about a new listener on the chain rather than on a clock** (#42).
+- **A single-steppable radisk** (#48): replacing its three sources of asynchrony at construction turns a flush into a list of steps, so "read after exactly k steps of the flush" becomes assertable — 44 interleavings in 0.5s, byte-identical across runs, where the equivalent statistical check was 24 pinned runs at 25 seconds each and still could not tell 30% from 42%.
+
 ## 1.0.38 — 2026-08-01
 
 ### EVM chains

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,4 +12,5 @@ This directory contains the ZEN developer book. Read the chapters in order for a
 | [Ch 6 — Networking](ch06-networking.md) | Mesh, peers, WebSocket, `zen.push()` ephemeral relay, DAM ping/RTT, AXE clustering |
 | [Ch 7 — PEN Policy VM](ch07-pen.md) | WASM bytecode engine, opcodes, `ZEN.pen()`, bridge/runtime policy enforcement |
 | [Ch 8 — Contributing](ch08-contributing.md) | Build system, test suite, adding chain methods, adding adapters |
+| [Ch 9 — MCP (AI Integration)](ch09-mcp.md) | IDE peer, stdio server, tools, Cursor/VSCode config |
 | [Ch 10 — EVM Chain Adapter](ch10-chains-evm.md) | `lib/chains/evm.js` — full ethers.js replacement using ZEN primitives, DeFi utilities, EIP-712 |

--- a/docs/ch04-authenticated-data.md
+++ b/docs/ch04-authenticated-data.md
@@ -291,7 +291,9 @@ console.log(bad);   // undefined
 
 ## 4.13 Security pipeline summary
 
-When any write arrives, the security middleware routes it through one of these handlers:
+Before any routing happens, **`check.pipe.forget` runs first for every soul without exception**: a write on an ephemeral `<?N` soul or key whose HAM state is already older than N seconds is dropped right there, ahead of ownership, policy and hash rules alike (§5.15).
+
+What survives that gate is then routed through one of these handlers:
 
 | Soul | Handler | What it checks |
 |------|---------|----------------|

--- a/docs/ch05-storage.md
+++ b/docs/ch05-storage.md
@@ -428,18 +428,25 @@ Absolute numbers above are from one machine (Node 24, ext4, `radisk` + `rfs`, si
 
 ## 5.15 Ephemeral souls — `<?N`
 
-A soul containing `<?N` (N in seconds) is **ephemeral**. Two independent mechanisms enforce it, and both are needed:
+A soul **or key** containing `<?N` (N in seconds) is **ephemeral**. Two independent mechanisms enforce it, and both are needed:
 
-1. **The sync gate** (`src/security.js`, `forget` pipe stage): any incoming copy whose HAM state is older than N seconds is dropped at ingest — stale data stops replicating, and a peer that arrives late never receives it.
-2. **The storage bypass** (`lib/store.js` for radisk and every RAD backend, `src/locstore.js` for browser localStorage): writes on ephemeral souls are ACKed like memory-only mode but never persisted. RAM is their only home — a restart forgets them.
+1. **The sync gate** (`src/security.js`, `forget` pipe stage — the FIRST stage of the pipeline, ahead of every ownership and policy rule): any incoming copy whose HAM state is older than N seconds is dropped at ingest. Stale data stops replicating, and a peer that arrives late never receives it.
+2. **The RAM store** (`lib/store.js`, covering radisk and every RAD backend): ephemeral writes never touch the disk. They are held in a per-instance map with a real per-key expiry parsed from the marker, and **reads are served from it** — swept lazily on every read and by an `unref()`'d 60-second timer.
 
 ```js
 zen.get("inbox<?300").get("latest").put(payload)   // whole node ephemeral
 zen.get(soul).get(pub + "<?300").put(payload)      // ONE slot of a durable node ephemeral
 ```
 
-The marker works at BOTH granularities: on the **soul** (every key of the node is ephemeral) and on a **key** (that slot alone). The key form is what a PEN mailbox uses — one public policy soul, each participant fenced into `key = <their recovered pub><?N`, every slot RAM-only (see `test/zen/mailbox.js` for the full pattern: `sign:true` + a `suf`/`let`/`seg` key rule).
+The marker works at BOTH granularities: on the **soul** (every key of the node is ephemeral) and on a **key** (that slot alone, inside an otherwise durable node). The key form is what a PEN mailbox uses — one public policy soul, each participant fenced into `key = <their recovered pub><?N`, every slot RAM-only. See §7.13 for the pattern and `test/zen/mailbox.js` for the worked example; `test/zen/ephemeral.js` pins the storage properties on their own.
 
-Half of this existed from the start (the sync gate); the storage bypass was restored in 1.0.41 after the rewrite had lost it — without it, "ephemeral" data outlived its window on every relay's disk, which is not ephemeral at all.
+### 5.15.1 What the two halves cost, and what they do not
 
-Composition notes: the marker is part of the soul STRING, so it composes with user-space (`~pub…<?N`) signature checks and with PEN policy souls — the `forget` stage runs before both (verified live: a signed put on `~pub/inbox<?60` acks, serves from RAM, and leaves no payload on disk). One honest nuance: the DURABLE parent node's link to an ephemeral child is part of the parent and does persist — the child's NAME is visible on disk, its data never is. Choose N by intent: it bounds how stale a copy may be and still spread, not an exact wall-clock deletion.
+- **Wall-clock expiry is real**, not merely a staleness bound: each key carries `now + N seconds`, and the sweep deletes it. A marker with no parseable N never expires until the process does.
+- **Only RAM, only this process.** There is no persistence, so a restart forgets everything ephemeral. That is the guarantee, not a limitation to work around.
+- **The browser half is put-only.** `src/locstore.js` skips persisting ephemeral writes but has no RAM store of its own — in a browser the in-memory chain cache is what serves. Nothing is written to `localStorage`, which is the property that matters there.
+- **One honest nuance:** a DURABLE parent's link to an ephemeral child belongs to the parent and does persist. The child's NAME can be read off disk; its data never can.
+
+### 5.15.2 History
+
+The sync gate existed from the start. The storage half was lost in the rewrite and restored in **1.0.41** — without it, "ephemeral" data outlived its window on every relay's disk, which is not ephemeral at all. 1.0.42 fixed the guard calling into an undefined soul (not every put frame carries one). **1.0.43** extended the marker to keys, which is what makes the mailbox pattern possible. **1.0.44** replaced the bypass with the RAM store above: skipping the disk was not enough, because a long-lived relay collects its chain cache and the data became unservable — acked into the void, invisible to any cold reader.

--- a/docs/ch07-pen.md
+++ b/docs/ch07-pen.md
@@ -79,12 +79,14 @@ When PEN is called from the ZEN bridge, registers are populated as follows:
 | `R[2]` | `soul` | The soul of the node |
 | `R[3]` | `state` | The HAM state timestamp |
 | `R[4]` | `now` | `Date.now()` — injected by the ZEN bridge |
-| `R[5]` | `pub` | The writer's public key (recovered from signature when `sign:true`) |
+| `R[5]` | `pub` | The writer's public key — recovered from the signature when `sign:true`, on the originating write **and** on re-propagation from a remote peer |
 | `R[6]` | `path` | Path after `pencode/` in soul (e.g. soul `!abc/foo/bar` → path `foo/bar`) |
 | `R[7]` | `nonce` | PoW nonce from `msg.put["^"]` — always reserved, never set by user |
 | `R[128–255]` | `local[n]` | Local slots, set by `LET` opcode |
 
 Host registers (`R[0..127]`) are provided by the ZEN bridge. Local registers (`R[128..255]`) are scratch space inside the policy.
+
+`R[5]` deserves a note, because writer-pinning policies live or die on it. A signed write reaches other peers as re-propagation, and until 1.0.44 the register was only truthful on the node that originated the write — remote peers verified the signature but left `R[5]` blank, so any policy comparing against it failed there. The symptom was silent and total: pen-soul data acked at the relay and was dropped at every subscriber. Both re-propagation paths now recover the signer before the predicate runs, and a write whose signer cannot be recovered is rejected with `PEN: cannot recover signer pub`. Remote peers are exactly where writer pinning matters most.
 
 ---
 
@@ -375,7 +377,40 @@ LET(0, DIVU(R[4], window),            ← current candle (R[128])
 
 ---
 
-## 7.13 Building PEN from source
+## 7.13 The mailbox pattern — policy-fenced ephemeral slots
+
+A `~pub` namespace admits exactly one writer, so it cannot host an inbox that other identities write into — not without issuing certificates, which ordinary participants cannot mint for themselves. The mailbox pattern solves the same problem with policy instead: **one public PEN soul where every writer is fenced into a slot named after their own recovered key.**
+
+```js
+const soul = await ZEN.pen({
+  sign: true,
+  key: {
+    and: [
+      { suf: "<?60" },                                  // every slot is ephemeral, by LAW
+      { let: { bind: 0,
+               def:  { seg: { of: { reg: 0 }, sep: "<", idx: 0 } },
+               body: { eq: [{ reg: 128 }, { reg: 5 }] } } },   // prefix === recovered writer
+    ],
+  },
+});
+
+// each participant writes only their own slot
+zen.get(soul).get(pair.pub + "<?60").put(payload, cb, { authenticator: pair });
+```
+
+Three separate guarantees, each from a different mechanism, and none of them trusting a claim in the message:
+
+- **Identity** comes from the signature. `R[5]` is the pub *recovered* from it (§7.4), never a field the writer filled in. A writer cannot address someone else's slot: `eq [reg 128, reg 5]` compares the key's prefix against the recovered signer.
+- **Fencing** comes from the policy, which travels inside the soul itself — the bytecode IS the address, so no configuration can drift away from it.
+- **Forgetting** comes from the `<?60` suffix, enforced by `suf` so a durable slot cannot be smuggled in. Ephemerality is a property of the mailbox, not a courtesy of its writers (§5.15).
+
+A one-slot-per-writer mailbox is last-write-wins by construction: the newest message is the one a returning reader catches up on, and past the window the mesh has forgotten it entirely. For a directed inbox — engine to user rather than any-to-any — pin the writer to a constant instead and let the soul path separate recipients: `key: { and: [enginePub + "<?300", { eq: [{ reg: 5 }, enginePub] }] }`, then write `soul + "/" + userPub`.
+
+One practical wrinkle for readers: a slot value arrives in one of **three shapes** depending on the path it took — unpacked plaintext (locally, where `penStage` already unwrapped it), a signed envelope object `{ ":": value, "~": signature }`, or that envelope serialized to a JSON string by the wire. Consumers should normalize all three; `unwrap()` in `test/zen/mailbox.js` is the reference implementation.
+
+---
+
+## 7.14 Building PEN from source
 
 PEN Core is written in Zig. The source lives at `src/pen.zig` and `src/wasm.zig`.
 
@@ -391,13 +426,15 @@ Zig must be on your `PATH`. See [ziglang.org](https://ziglang.org/download/) to 
 
 ---
 
-## 7.14 Testing PEN
+## 7.15 Testing PEN
 
 ```bash
 npm run test:pen:unit
 ```
 
-This runs `test/pen.js` with a 10-second timeout. Tests cover:
+This runs `test/pen.js` with a 10-second timeout. The mailbox pattern of §7.13 has its own suite — `test/zen/mailbox.js`, part of `npm run test:zen:unit` — covering both the offline fencing rules and the over-the-wire propagation that `R[5]` recovery makes possible.
+
+`test/pen.js` tests cover:
 - `pen.pack` / `pen.unpack` round-trips
 - `pen.bc.*` bytecode builder
 - `pen.run(bytecode, regs)` evaluation

--- a/docs/ch08-contributing.md
+++ b/docs/ch08-contributing.md
@@ -62,7 +62,7 @@ npm run unbuildZEN
 
 ## 8.4 Test suite
 
-ZEN has three test suites, all run via Mocha.
+ZEN's tests are grouped into suites, all run via Mocha. `npm test` runs `build:zen` first, then `test/all.js`, which drives every group below.
 
 ### Run all tests
 
@@ -70,14 +70,17 @@ ZEN has three test suites, all run via Mocha.
 npm test
 ```
 
-This runs `build:zen` first, then all three suites.
+This runs `build:zen` first, then `test/all.js` — the whole set, including the chain, DHT and MCP groups that the individual commands below leave out.
 
 ### Individual suites
 
 ```bash
 npm run test:pen:unit    # PEN VM tests (test/pen.js)
-npm run test:zen:unit    # ZEN unit tests (test/zen/*.js)
-npm run test:core       # Core graph tests (test/zen.js, test/rad/*, etc.)
+npm run test:zen:unit    # ZEN unit tests (test/zen/*.js + test/mesh/dam.js)
+npm run test:core        # Core graph tests (test/zen.js, test/rad/*, etc.)
+npm run test:chains      # EVM adapter (test/chains/evm.js)
+npm run test:dht         # DHT k-buckets
+npm run test:mcp         # MCP stdio server
 ```
 
 ### Test file map
@@ -85,9 +88,10 @@ npm run test:core       # Core graph tests (test/zen.js, test/rad/*, etc.)
 | Suite | Files | What it tests |
 |-------|-------|---------------|
 | `test:pen:unit` | `test/pen.js` | PEN bytecode, pack/unpack, policy execution |
-| `test:zen:unit` | `test/zen/instance.js`, `secp256k1.js`, `crypto.js`, `multicurve.js`, `certify.js`, `recover.js`, `push.js`, `meta.js` | ZEN instance API, crypto primitives, chain methods |
-| `test:core` | `test/abc.js`, `test/rad/rad.js`, `test/radix.js`, `test/zen.js` | Graph operations, Radisk, core behavior |
-| `test:mesh` (standalone) | `test/mesh/dam.js` | DAM ping/pong RTT, XOR routing, relay multi-hop |
+| `test:zen:unit` | `test/zen/`: `instance`, `nostore`, `concurrent-writes`, `read-after-write`, `bootstrap`, `secp256k1`, `crypto`, `multicurve`, `certify`, `recover`, `push`, `port`, `status`, `ephemeral`, `mailbox` — plus `test/mesh/dam.js` | ZEN instance API, crypto primitives, read-after-write, ephemeral `<?N` souls and the PEN mailbox pattern, DAM relay |
+| `test:core` | `test/abc.js`, `test/rad/rad.js`, `test/rad/flush-read.js`, `test/rad/invariants.js`, `test/radix.js`, `test/zen.js` | Graph operations, Radisk (including the single-steppable flush invariants), core behavior |
+| `test:chains` | `test/chains/evm.js` | EVM adapter: ABI codec, providers, WsProvider subscriptions, EIP-712 |
+| `test:chains:fork` | `test/chains/evm-fork.js` | Mainnet fork integration (needs `ETH_RPC`) |
 
 ### Clean data before testing
 
@@ -287,7 +291,7 @@ npm test                  # run full test suite
 node test/panic/holy-grail.js  # run correctness tests
 ```
 
-Current baseline: `557 passing` via `npm test`. Keep that green before submitting a pull request.
+Current baseline: `812 passing, 39 pending, 0 failing` via `npm test` (1.0.44). Keep that green before submitting a pull request.
 
 ---
 

--- a/docs/ch10-chains-evm.md
+++ b/docs/ch10-chains-evm.md
@@ -141,8 +141,9 @@ Có đầy đủ HTTP provider methods + subscriptions. Điểm nổi bật:
 Nếu WebSocket bị ngắt kết nối (server restart, network flicker), WsProvider tự động:
 1. Đợi `reconnectDelay` ms (mặc định 1000ms)
 2. Reconnect
-3. Re-subscribe tất cả subscriptions đã đăng ký
+3. Re-subscribe tất cả subscriptions đã đăng ký — **đúng nguyên tham số**, không chỉ tên topic: mỗi subscription lưu `{ handler, params }` nên một filter logs được đăng ký lại y hệt filter cũ
 4. Delay tăng theo exponential backoff (x2 mỗi lần), tối đa 30 giây
+5. Bắn `reconnect` (nếu có handler) — **sau** bước 3, để bên tiêu thụ vá khe trước khi event mới đổ vào
 
 ```js
 const ws = wsRpc("wss://...")
@@ -154,24 +155,64 @@ const subId = await ws.on("block", (blockNumber) => {
 
 // Hủy subscription
 await ws.off("block")
-
-// Dừng hoàn toàn (không reconnect nữa)
-await ws.destroy()
 ```
 
 ### Subscribe events
 
 ```js
-// Block mới
+// Block mới — parity với ethers: callback nhận SỐ block
 await ws.on("block", (blockNumber) => { ... })
 
-// Error handler
+// Error handler (không mở kết nối, chỉ ghi handler)
 await ws.on("error", (err) => { ... })
 
 // Hủy theo subscription ID
 const subId = await ws.on("block", handler)
 await ws.off(subId)
 ```
+
+### `on("head")` — nguyên header, khỏi tốn `getBlock`
+
+`on("block")` giữ parity với ethers nên nó rút header xuống còn mỗi số block. Bên nào cần **timestamp thật của block** — ví dụ đóng dấu thời gian cho nến — thì dùng `on("head")`: cùng kênh `newHeads`, nhưng callback nhận nguyên header đã enrich (có `block.date`), nên luồng sống không phải gọi `getBlock` một lần mỗi block.
+
+```js
+await ws.on("head", (header) => {
+    const ts = parseInt(header.timestamp, 16) * 1000   // mốc thật, không nội suy
+})
+await ws.off("head")
+```
+
+Hai kênh sống song song và cùng được đăng ký lại sau reconnect.
+
+### `on(filter)` — subscription logs
+
+Truyền một **object** thay vì tên sự kiện thì đó là subscription `logs` (parity ethers): provider gửi `eth_subscribe ["logs", filter]` và callback nhận từng log.
+
+```js
+const filter = { address: [poolA, poolB], topics: [SWAP_TOPIC] }
+await ws.on(filter, (log) => { ... })
+
+// Hủy bằng CHÍNH object filter đó (khoá nội bộ là JSON của nó)
+await ws.off(filter)
+```
+
+Filter sống sót qua reconnect nguyên vẹn. Đổi tập địa chỉ theo dõi thì `off(filterCũ)` rồi `on(filterMới)`.
+
+### `on("reconnect")` — tín hiệu vá khe
+
+```js
+await ws.on("reconnect", () => healFrom(lastProcessedBlock))
+```
+
+Chỉ bắn **sau khi** mọi subscription đã đăng ký lại, nên bên tiêu thụ không bao giờ thấy event mới rơi vào một khoảng chưa vá. `reconnect` và `error` là hai đăng ký **không mở kết nối** — gọi chúng trước khi dial cũng được.
+
+### `destroy()` — dừng thật sự
+
+```js
+await ws.destroy()
+```
+
+Đóng socket, chặn mọi reconnect, xoá sạch bảng subscription/handler, và **reject mọi lời gọi đang treo** bằng `WS destroyed`. Trước 1.0.44 nó chỉ đóng socket: các call đang chờ treo tới hết timeout, bảng subscription sống nguyên, và một provider đã bị bỏ rơi vẫn tự reconnect như một cái xác chạy rông. Bên tiêu thụ phải bắt được lỗi `WS destroyed` từ các call đang bay.
 
 ---
 
@@ -742,8 +783,8 @@ parseUnits("1.5", 6)               // → 1500000n
 
 | Suite | Số test | Chạy bằng |
 |---|---|---|
-| Unit (evm.js) | 76 | `npm run test:chains` |
-| Fork integration | 38 | `ETH_RPC=... npm run test:chains:fork` |
+| Unit (evm.js) | 90 | `npm run test:chains` |
+| Fork integration | 40 | `ETH_RPC=... npm run test:chains:fork` |
 
 Fork tests dùng ganache fork mainnet tại block 19,500,000 qua Infura, test đầy đủ:
 - Provider primitives (getBalance, getCode, getBlock, estimateGas)
@@ -795,7 +836,7 @@ const sig = await ZEN.sign("0x" + hashHex, pair, null, { prehash: true, encode: 
 ## See also
 
 - `lib/chains.js` — re-export entry point: `import chains from "@akaoio/zen/lib/chains.js"`
-- `test/chains/evm.js` — 76 unit tests
-- `test/chains/evm-fork.js` — 38 mainnet fork integration tests
+- `test/chains/evm.js` — 90 unit tests
+- `test/chains/evm-fork.js` — 40 mainnet fork integration tests
 - `docs/ch03-crypto.md` — ZEN crypto primitives (`pair`, `sign`, `hash`, v.v.)
 - GitHub Issue #27 — `ethers-replacement` branch tracking

--- a/docs/pen/03_registers.md
+++ b/docs/pen/03_registers.md
@@ -98,7 +98,7 @@ shortcut: 0xFB"]
 | R[2] | `0xF2` | Full soul string (`!...`) | Soul này có đúng như expected không? |
 | R[3] | `0xF3` | HAM state timestamp (float ms) | Write này có trong cửa sổ thời gian không? |
 | R[4] | `0xF4` | `Date.now()` tại thời điểm validate | Kiểm tra relative timing |
-| R[5] | `0xF5` | Public key của người đang ghi | Writer có phải Alice không? |
+| R[5] | `0xF5` | Public key của người đang ghi — **recover từ chữ ký**, cả khi ghi mới lẫn khi bản ghi tới từ peer khác (xem `04_write-pipeline.md` ④) | Writer có phải Alice không? |
 | R[6] | — | Path segment (phần sau `/` trong soul) | Path có đúng không? |
 | R[7] | — | PoW nonce (từ `ctx.put['^']`) | Nonce có hợp lệ không? (dùng trong PoW verify) |
 

--- a/docs/pen/04_write-pipeline.md
+++ b/docs/pen/04_write-pipeline.md
@@ -156,12 +156,23 @@ Xem thêm tại [Lớp 6 — PoW](06_pow.md).
 ### ④ Xác định Writer
 
 ```javascript
+// Ghi mới (chính node này khởi phát)
 var writer = sec.upub                  // User đang đăng nhập
            || authenticator && authenticator.pub  // Hoặc auth service
            || null
+
+// Re-propagation (bản ghi ĐÃ KÝ tới từ peer khác) — phải RECOVER
+runtime.recover(packed).then(function (signerPub) {
+  runtime.verify(packed, signerPub, function (data) {
+    writer = signerPub          // ← R[5] cho nhánh này
+    ...
+  })
+})
 ```
 
 Writer's public key → nạp vào `R[5]` trước khi gọi VM.
+
+**Vì sao nhánh re-propagation phải recover** (sửa 1.0.44): trước đó nó verify chữ ký nhưng để `writer` rỗng, nên mọi policy so với `R[5]` **fail trên mọi peer từ xa**. Triệu chứng im lặng và toàn phần: dữ liệu pen-soul được ack ở relay rồi bị drop ở từng subscriber — không lỗi, không log, chỉ là không bao giờ tới. Mà peer từ xa mới chính là chỗ việc ghim-người-ghi có ý nghĩa nhất. Không recover được thì write bị từ chối bằng `PEN: cannot recover signer pub`.
 
 ---
 


### PR DESCRIPTION
Six releases shipped since the docs last matched the code; every claim here was re-checked against current source.

| Doc | Was wrong / missing |
|---|---|
| `ch05` §5.15 | called the ephemeral half a "storage bypass" — it is a **RAM store that serves reads** with real per-key expiry. Adds: no-N ⇒ never expires; the browser half is put-only. History now ends at 1.0.44 |
| `ch07` §7.13 **(new)** | the **mailbox pattern** had no home: one public policy soul, writers fenced into their own recovered-pub slot, ephemerality by law. §7.4 explains why `R[5]` on re-propagation is load-bearing |
| `ch10` | the entire 1.0.40 WsProvider surface was undocumented: `on(filter)`, `on("head")`, `on("reconnect")`, a real `destroy()`, filter replay across reconnects. Test counts 76→90, 38→40 |
| `ch04` §4.13 | the `forget` stage runs **first for every soul** — the routing table could not tell you that |
| `pen/03`, `pen/04` | R5 recovery on both write paths |
| `ch08` | "three test suites" was four suites ago; baseline 557 → **812 passing** |
| `docs/README` | Chapter 9 missing from the index |
| `CHANGELOG` | 1.0.39–1.0.44 written up, including the read-after-write hunt (#36–#58) that shipped without an entry |

Docs only — no source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)