### PR TITLE
fix(stats): never write state into the package directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ playwright-report/
 test-results/
 lib/reboot.cron
 stats.testzen-*
+# runtime stats writer droppings (pre-1.0.45 they landed in the package root)
+stats.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 1.0.45 — 2026-08-09
+
+### Storage
+
+- **The stats writer never writes into the package directory again** (`lib/stats.js`): under `GUN_TEST_TMP` it resolved its state *next to this module*, which for any consumer means writing inside `node_modules`. akao vendors zen by symlinking `src/core/ZEN` at the package, so those writes surfaced inside its **source tree** — and its dev server, watching `src/`, rebuilt in a loop over them: a page opened during that loop fetched a half-written module graph and never mounted its route. Test-mode state now goes to `<cwd>/tmp`, the convention `lib/tpath.js` already uses for every other data path. A library has no business writing into its own package directory, test mode or not.
+- `clean.js` sweeps `stats.*` and `.gitignore` covers them — this repo had ~140 of them accumulated in its own root, which is how visible the bug had been all along without being seen.
+- New suite `test/zen/stats-path.js` pins the invariant: a running instance must leave the package directory untouched and put its state under `tmp/`. Verified red on the old path, green on the new. Full suite 813 passing, 39 pending, 0 failing.
+
 ## 1.0.44 — 2026-08-09
 
 ### PEN

--- a/clean.js
+++ b/clean.js
@@ -2,6 +2,16 @@ import fs from "node:fs";
 
 // CWD-relative cleanup — npm scripts always run from project root
 const drop = ["tmp", "radata", "radatatest", "data", "data.json"];
+
+// stats.* are the runtime writer's droppings; before 1.0.45 they landed here
+// instead of tmp/, and a repo full of them is what made the bug visible.
+for (const name of fs.readdirSync(".")) {
+  if (name.startsWith("stats.")) {
+    try {
+      fs.rmSync(name, { force: true });
+    } catch (e) {}
+  }
+}
 for (const d of drop) {
   try {
     fs.rmSync(d, {

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -29,9 +29,24 @@ Zen.on("opt", function (root) {
   var noop = function () {};
   var os = __os || {};
   var fs = __fs || {};
-  var stateDir = process.env.GUN_TEST_TMP === "1"
-    ? __path.resolve(__dirname, "..")
-    : xdg.ensure(xdg.state());
+  // Under test, state goes to <cwd>/tmp — the convention lib/tpath.js already
+  // uses for every other data path. It used to resolve NEXT TO THIS MODULE,
+  // which in any consumer means writing inside node_modules; akao vendors zen
+  // by symlinking src/core/ZEN at the package, so those writes surfaced inside
+  // its SOURCE TREE and its dev server rebuilt in a loop over them. A library
+  // has no business writing into its own package directory, test mode or not.
+  var stateDir;
+  if (process.env.GUN_TEST_TMP === "1") {
+    stateDir = __path.resolve(
+      process.cwd(),
+      (process.env.GUN_TMP_DIR || "tmp")
+    );
+    try {
+      fs.mkdirSync(stateDir, { recursive: true });
+    } catch (e) {}
+  } else {
+    stateDir = xdg.ensure(xdg.state());
+  }
   var stateFile = function (f) { return __path.join(stateDir, "stats." + f); };
   fs.existsSync = fs.existsSync || path.existsSync;
   if (!fs.existsSync) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@akaoio/zen",
   "type": "module",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "description": "A realtime, decentralized, offline-first, graph data synchronization engine.",
   "main": "index.min.js",
   "browser": "zen.min.js",
@@ -32,7 +32,7 @@
     "test:core": "npm run clean && cross-env GUN_TEST_TMP=1 ZEN_SILENCE_TEST_WARNINGS=1 node --import ./test/loaders/register-zen-minified.mjs ./node_modules/mocha/bin/_mocha --exit test/abc.js test/rad/rad.js test/rad/flush-read.js test/rad/invariants.js test/radix.js test/zen.js",
     "test:mesh": "npm run clean && cross-env GUN_TEST_TMP=1 ZEN_TEST=1 node --import ./test/loaders/register-zen-minified.mjs ./node_modules/mocha/bin/_mocha --exit test/mesh/dam.js --timeout 10000",
     "test:dht": "cross-env GUN_TEST_TMP=1 ZEN_TEST=1 node --import ./test/loaders/register-zen-minified.mjs ./node_modules/mocha/bin/_mocha --exit test/dht/kbucket.js --timeout 10000",
-    "test:zen:unit": "npm run clean && cross-env GUN_TEST_TMP=1 ZEN_TEST=1 node --import ./test/loaders/register-zen-minified.mjs ./node_modules/mocha/bin/_mocha --exit test/zen/instance.js test/zen/nostore.js test/zen/concurrent-writes.js test/zen/read-after-write.js test/zen/bootstrap.js test/zen/secp256k1.js test/zen/crypto.js test/zen/multicurve.js test/zen/certify.js test/zen/recover.js test/zen/push.js test/zen/port.js test/zen/status.js test/zen/ephemeral.js test/zen/mailbox.js test/mesh/dam.js",
+    "test:zen:unit": "npm run clean && cross-env GUN_TEST_TMP=1 ZEN_TEST=1 node --import ./test/loaders/register-zen-minified.mjs ./node_modules/mocha/bin/_mocha --exit test/zen/instance.js test/zen/nostore.js test/zen/concurrent-writes.js test/zen/read-after-write.js test/zen/bootstrap.js test/zen/secp256k1.js test/zen/crypto.js test/zen/multicurve.js test/zen/certify.js test/zen/recover.js test/zen/push.js test/zen/port.js test/zen/status.js test/zen/stats-path.js test/zen/ephemeral.js test/zen/mailbox.js test/mesh/dam.js",
     "test:zen": "npm run build:zen && npm run test:zen:unit",
     "e2e": "mocha e2e/distributed.js",
     "docker": "hooks/build",

--- a/test/zen/stats-path.js
+++ b/test/zen/stats-path.js
@@ -1,0 +1,71 @@
+import zenbase from "../../zen.js";
+import "../../lib/store.js";
+import assert from "assert";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// A library must never write into its own package directory. zen's stats
+// writer used to resolve its state next to the module under GUN_TEST_TMP,
+// which lands inside node_modules for every consumer — and akao vendors zen by
+// symlinking src/core/ZEN at the package, so those writes appeared inside its
+// SOURCE tree and its dev server rebuilt in a loop over them. Test mode means
+// <cwd>/tmp, the same convention lib/tpath.js uses for every other data path.
+
+const PACKAGE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const TMP_DIR = path.resolve(process.cwd(), process.env.GUN_TMP_DIR || "tmp");
+
+function statsFiles(dir) {
+  try {
+    return fs
+      .readdirSync(dir)
+      .filter((name) => name.startsWith("stats."))
+      .map((name) => {
+        const full = path.join(dir, name);
+        return { name, mtime: fs.statSync(full).mtimeMs };
+      });
+  } catch (e) {
+    return [];
+  }
+}
+
+describe("stats state never lands in the package directory", function () {
+  this.timeout(30000);
+
+  it("writes under <cwd>/tmp in test mode, and touches nothing in the package root", async function () {
+    assert.strictEqual(process.env.GUN_TEST_TMP, "1", "this test only means anything in test mode");
+
+    const before = statsFiles(PACKAGE_ROOT);
+    const zen = new zenbase({
+      peers: [],
+      multicast: false,
+      axe: false,
+      WebSocket: false,
+      localStorage: false,
+      radisk: true,
+      file: "stats-path-probe",
+    });
+    assert.ok(zen);
+
+    // the writer runs on a 5s interval; give it one full turn plus slack
+    await new Promise(function (resolve) {
+      setTimeout(resolve, 7000);
+    });
+
+    const after = statsFiles(PACKAGE_ROOT);
+    const changed = after.filter((entry) => {
+      const previous = before.find((each) => each.name === entry.name);
+      return !previous || previous.mtime !== entry.mtime;
+    });
+    assert.deepStrictEqual(
+      changed.map((entry) => entry.name),
+      [],
+      "no stats file may be created or rewritten inside the package directory"
+    );
+
+    assert.ok(
+      statsFiles(TMP_DIR).some((entry) => entry.name.includes("stats-path-probe")),
+      `test-mode stats belong in ${TMP_DIR} — found ${JSON.stringify(statsFiles(TMP_DIR).map((e) => e.name))}`
+    );
+  });
+});


### PR DESCRIPTION
`lib/stats.js` resolved its state **next to its own module** under `GUN_TEST_TMP` — i.e. inside `node_modules` for every consumer. akao vendors zen by symlinking `src/core/ZEN` at the package, so those writes landed in its **source tree**; its dev server watches `src/` and rebuilt in a loop, and any page opened during that loop fetched a half-written module graph and never mounted its route.

- Test-mode state → `<cwd>/tmp`, matching `lib/tpath.js`'s convention for every other data path.
- `clean.js` sweeps `stats.*`; `.gitignore` covers them. This repo had **~140** accumulated in its own root.
- New `test/zen/stats-path.js`: an instance must leave the package directory untouched and write under `tmp/`. **Red on the old path, green on the new.**

Full suite **813 passing, 0 failing**. **v1.0.45**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)