### PR TITLE
feat(cli): zen doctor — say when the install has drifted from the checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ zen stop        # stop the relay service
 zen restart     # restart the relay service
 zen logs        # follow journalctl live logs
 zen update      # pull latest & restart
+zen doctor      # check the install still matches the checkout (--fix, --deep)
 zen uninstall   # remove everything
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@akaoio/zen",
   "type": "module",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "description": "A realtime, decentralized, offline-first, graph data synchronization engine.",
   "main": "index.min.js",
   "browser": "zen.min.js",
@@ -32,7 +32,7 @@
     "test:core": "npm run clean && cross-env GUN_TEST_TMP=1 MULTICAST=false ZEN_SILENCE_TEST_WARNINGS=1 node --import ./test/loaders/register-zen-minified.mjs ./node_modules/mocha/bin/_mocha --exit test/abc.js test/rad/rad.js test/rad/flush-read.js test/rad/invariants.js test/rad/prefix-siblings.js test/radix.js test/zen.js",
     "test:mesh": "npm run clean && cross-env GUN_TEST_TMP=1 MULTICAST=false node --import ./test/loaders/register-zen-minified.mjs ./node_modules/mocha/bin/_mocha --exit test/mesh/dam.js --timeout 10000",
     "test:dht": "cross-env GUN_TEST_TMP=1 MULTICAST=false node --import ./test/loaders/register-zen-minified.mjs ./node_modules/mocha/bin/_mocha --exit test/dht/kbucket.js --timeout 10000",
-    "test:zen:unit": "npm run clean && cross-env GUN_TEST_TMP=1 MULTICAST=false node --import ./test/loaders/register-zen-minified.mjs ./node_modules/mocha/bin/_mocha --exit test/zen/instance.js test/zen/nostore.js test/zen/concurrent-writes.js test/zen/read-after-write.js test/zen/link-delivery.js test/zen/hatch-swallow.js test/zen/bootstrap.js test/zen/secp256k1.js test/zen/crypto.js test/zen/multicurve.js test/zen/certify.js test/zen/recover.js test/zen/push.js test/zen/port.js test/zen/status.js test/zen/late-peer.js test/zen/stats-path.js test/zen/ephemeral.js test/zen/mailbox.js test/mesh/dam.js",
+    "test:zen:unit": "npm run clean && cross-env GUN_TEST_TMP=1 MULTICAST=false node --import ./test/loaders/register-zen-minified.mjs ./node_modules/mocha/bin/_mocha --exit test/zen/instance.js test/zen/nostore.js test/zen/concurrent-writes.js test/zen/read-after-write.js test/zen/link-delivery.js test/zen/hatch-swallow.js test/zen/doctor.js test/zen/bootstrap.js test/zen/secp256k1.js test/zen/crypto.js test/zen/multicurve.js test/zen/certify.js test/zen/recover.js test/zen/push.js test/zen/port.js test/zen/status.js test/zen/late-peer.js test/zen/stats-path.js test/zen/ephemeral.js test/zen/mailbox.js test/mesh/dam.js",
     "test:zen": "npm run build:release && npm run test:zen:unit",
     "e2e": "mocha e2e/distributed.js",
     "docker": "hooks/build",

--- a/script/zen.sh
+++ b/script/zen.sh
@@ -172,6 +172,226 @@ cmd_update() {
     exec "$install_dir/script/update.sh" "$@"
 }
 
+# ── zen doctor ────────────────────────────────────────────────────────────────
+# Everything here answers one question: is what is installed still what this
+# checkout says it should be? Nothing on this machine errors when the answer is
+# no. The auto-update timer sat enabled, active and dead for eight days without
+# a single log line, and every deploy in that window quietly needed a human.
+DOCTOR_BAD=0
+DOCTOR_DEEP=0
+DOCTOR_FIX=0
+
+doc_ok()   { printf '  %s✓%s %-20s %s\n' "$GREEN" "$NC" "$1" "$2"; }
+doc_warn() { printf '  %s!%s %-20s %s\n' "$YELLOW" "$NC" "$1" "$2"; DOCTOR_BAD=1; }
+doc_bad()  { printf '  %s✗%s %-20s %s\n' "$RED" "$NC" "$1" "$2"; DOCTOR_BAD=1; }
+doc_fix()  { printf '      %s%s%s\n' "$CYAN" "$1" "$NC"; }
+
+# systemd reports the next firing twice: on the wall clock and on the monotonic
+# clock. A timer with neither is enabled, active, and dead.
+doctor_timer_dead() {
+    local rt mono
+    rt=$(systemctl show "$1" -p NextElapseUSecRealtime --value 2>/dev/null || echo "")
+    mono=$(systemctl show "$1" -p NextElapseUSecMonotonic --value 2>/dev/null || echo "")
+    case "$rt" in "" | 0 | n/a | infinity) ;; *) return 1 ;; esac
+    case "$mono" in "" | 0 | n/a | infinity) ;; *) return 1 ;; esac
+    return 0
+}
+
+cmd_doctor() {
+    local install_dir svc ver node_bin exec_start head stamp behind sep
+    local unit tmpl want have free data_dir
+
+    for a in "$@"; do
+        case "$a" in
+            --deep) DOCTOR_DEEP=1 ;;
+            --fix)  DOCTOR_FIX=1 ;;
+            *) err "Unknown option: $a"; exit 1 ;;
+        esac
+    done
+
+    install_dir=$(find_install_dir || true)
+    svc=$(get_service_name)
+    sep="────────────────────────────────"
+    printf '%sZEN doctor%s\n%s\n' "$BOLD" "$NC" "$sep"
+
+    # ── install ───────────────────────────────────────────────────────────────
+    if [ -z "$install_dir" ]; then
+        doc_bad "install" "not found"
+        doc_fix "curl -fsSL https://raw.githubusercontent.com/akaoio/zen/main/script/install.sh | bash"
+        exit 1
+    fi
+    ver=$(node -e "process.stdout.write(require('$install_dir/package.json').version)" 2>/dev/null || echo "?")
+    doc_ok "install" "$install_dir (v$ver)"
+
+    node_bin=$(command -v node 2>/dev/null || true)
+    if [ -z "$node_bin" ]; then
+        doc_bad "node" "not on PATH"
+    else
+        doc_ok "node" "$($node_bin --version) at $node_bin"
+    fi
+
+    if ! command -v systemctl >/dev/null 2>&1; then
+        doc_warn "systemd" "not available — service checks skipped"
+        doctor_summary "$sep"
+        return $?
+    fi
+
+    # ── the relay ─────────────────────────────────────────────────────────────
+    if systemctl is-active --quiet "$svc" 2>/dev/null; then
+        doc_ok "service" "$svc active"
+    else
+        doc_bad "service" "$svc $(systemctl is-active "$svc" 2>/dev/null || echo 'not installed')"
+        doc_fix "zen start"
+    fi
+
+    # A unit left behind by an older install can still be running happily from a
+    # directory this checkout knows nothing about.
+    exec_start=$(systemctl show "$svc" -p ExecStart --value 2>/dev/null | sed -n 's/.*path=\([^ ;]*\).*/\1/p' || true)
+    case "$(systemctl show "$svc" -p ExecStart --value 2>/dev/null)" in
+        *"$install_dir"*) doc_ok "service points at" "$install_dir" ;;
+        "") doc_warn "service points at" "unknown" ;;
+        *) doc_bad "service points at" "somewhere else, not $install_dir"
+           doc_fix "re-run install.sh, or check ExecStart in /etc/systemd/system/$svc.service" ;;
+    esac
+    if [ -n "$exec_start" ] && [ ! -x "$exec_start" ]; then
+        doc_bad "service node" "$exec_start is gone"
+        doc_fix "re-run install.sh to point the unit at the node you have now"
+    fi
+
+    # ── is the relay running this checkout? ───────────────────────────────────
+    head=$(git -C "$install_dir" rev-parse HEAD 2>/dev/null || echo "")
+    stamp=$(cat "$ZEN_STATE_DIR/deployed-commit-${svc}" 2>/dev/null || echo "")
+    if [ -z "$head" ]; then
+        doc_warn "checkout" "not a git checkout"
+    elif [ -z "$stamp" ]; then
+        doc_warn "deployed" "no record of what was deployed"
+        doc_fix "zen update"
+    elif [ "$head" = "$stamp" ]; then
+        doc_ok "deployed" "$(printf '%.7s' "$head") — the running service is this commit"
+    else
+        doc_bad "deployed" "service is on $(printf '%.7s' "$stamp"), checkout is $(printf '%.7s' "$head")"
+        doc_fix "zen update"
+    fi
+
+    # ── is this checkout behind its upstream? ─────────────────────────────────
+    if [ -n "$head" ]; then
+        if timeout 20 git -C "$install_dir" fetch --quiet origin 2>/dev/null; then
+            behind=$(git -C "$install_dir" rev-list --count "HEAD..@{upstream}" 2>/dev/null || echo "?")
+            if [ "$behind" = "0" ]; then
+                doc_ok "upstream" "up to date"
+            elif [ "$behind" = "?" ]; then
+                doc_warn "upstream" "no upstream branch set"
+            else
+                doc_bad "upstream" "$behind commit(s) behind"
+                doc_fix "zen update"
+            fi
+        else
+            doc_warn "upstream" "could not reach origin (offline?)"
+        fi
+    fi
+
+    # ── the machinery that is supposed to do all this without me ─────────────
+    if systemctl list-unit-files --type=timer 2>/dev/null | grep -q "${svc}-update.timer"; then
+        if doctor_timer_dead "${svc}-update.timer"; then
+            doc_bad "auto-update" "timer has no next firing: enabled, active, and dead"
+            doc_fix "zen doctor --fix   (or re-run install.sh)"
+        else
+            doc_ok "auto-update" "next $(systemctl show "${svc}-update.timer" -p NextElapseUSecRealtime --value 2>/dev/null)"
+        fi
+    else
+        doc_bad "auto-update" "timer not installed"
+        doc_fix "re-run install.sh"
+    fi
+
+    # The units this checkout owns as templates. zen.service is not among them:
+    # install.sh builds that one inline, from options this command cannot know.
+    for unit in "${svc}-update.service" "${svc}-update.timer"; do
+        tmpl="$install_dir/script/$(printf '%s' "$unit" | sed "s|^${svc}|zen|")"
+        [ -f "$tmpl" ] && [ -f "/etc/systemd/system/$unit" ] || continue
+        want=$(sed -e "s|__ZEN_USER__|$(id -un)|g" -e "s|__ZEN_DIR__|$install_dir|g" -e "s|__ZEN_SERVICE__|$svc|g" "$tmpl")
+        have=$(cat "/etc/systemd/system/$unit")
+        if [ "$want" = "$have" ]; then
+            doc_ok "unit $unit" "matches this checkout"
+        else
+            doc_bad "unit $unit" "differs from this checkout"
+            doc_fix "zen doctor --fix"
+        fi
+    done
+
+    # ── where the data lives ─────────────────────────────────────────────────
+    data_dir="$ZEN_DATA_DIR/radata"
+    if [ -d "$data_dir" ]; then
+        if [ -w "$data_dir" ]; then
+            free=$(df -Pm "$data_dir" 2>/dev/null | awk 'NR==2 {print $4}')
+            if [ -n "$free" ] && [ "$free" -lt 200 ]; then
+                doc_bad "disk" "${free}MB free where the graph is written"
+            else
+                doc_ok "disk" "${free}MB free at $data_dir"
+            fi
+        else
+            doc_bad "data" "$data_dir is not writable"
+        fi
+    else
+        doc_warn "data" "$data_dir does not exist yet"
+    fi
+
+    # ── the store itself, only when asked: this reads every key back ─────────
+    if [ "$DOCTOR_DEEP" = 1 ]; then
+        printf '  %s…%s %-20s %s\n' "$CYAN" "$NC" "store" "reading every key back, this takes a while"
+        if node "$install_dir/script/radcheck.js" >/dev/null 2>&1; then
+            doc_ok "store" "every key on disk reads back"
+        else
+            doc_bad "store" "some keys do not read back"
+            doc_fix "node $install_dir/script/radcheck.js --all"
+        fi
+    fi
+
+    if [ "$DOCTOR_FIX" = 1 ]; then
+        doctor_apply "$install_dir" "$svc"
+        return $?
+    fi
+
+    doctor_summary "$sep"
+    return $?
+}
+
+doctor_summary() {
+    printf '%s\n' "$1"
+    if [ "$DOCTOR_BAD" = 0 ]; then
+        info "Nothing to fix."
+        return 0
+    fi
+    printf '%sSomething above needs attention. `zen doctor --fix` handles the unit files;%s\n' "$YELLOW" "$NC"
+    printf '%sthe rest are one-liners printed next to each finding.%s\n' "$YELLOW" "$NC"
+    return 1
+}
+
+# Only the units this checkout owns, rewritten from its own templates. Anything
+# a human put in them by hand -- the HTTPS lines ssl.sh adds, for one -- lives in
+# zen.service, which this does not touch.
+doctor_apply() {
+    local install_dir svc SUDO unit tmpl
+    install_dir="$1"
+    svc="$2"
+    SUDO=$(get_sudo)
+    printf '%s\n' "────────────────────────────────"
+    for unit in "${svc}-update.service" "${svc}-update.timer"; do
+        tmpl="$install_dir/script/$(printf '%s' "$unit" | sed "s|^${svc}|zen|")"
+        [ -f "$tmpl" ] || continue
+        info "Writing /etc/systemd/system/$unit from $tmpl"
+        sed -e "s|__ZEN_USER__|$(id -un)|g" -e "s|__ZEN_DIR__|$install_dir|g" -e "s|__ZEN_SERVICE__|$svc|g" \
+            "$tmpl" | $SUDO tee "/etc/systemd/system/$unit" > /dev/null
+    done
+    $SUDO systemctl daemon-reload
+    $SUDO systemctl restart "${svc}-update.timer"
+    if doctor_timer_dead "${svc}-update.timer"; then
+        err "The timer still has no next firing. Look at: systemctl status ${svc}-update.timer"
+        return 1
+    fi
+    info "Auto-update timer fires next at $(systemctl show "${svc}-update.timer" -p NextElapseUSecRealtime --value 2>/dev/null)"
+    return 0
+}
+
 # ── service helpers ───────────────────────────────────────────────────────────
 get_service_name() {
     local svc
@@ -285,6 +505,9 @@ ${BOLD}USAGE${NC}
 
 ${BOLD}COMMANDS${NC}
     status      Show relay status, service state, and XDG paths
+    doctor      Check that what is installed still matches this checkout
+                  --fix    rewrite the auto-update units from this checkout
+                  --deep   also read every key in the store back
     start       Start the relay service
     stop        Stop the relay service
     restart     Restart the relay service
@@ -308,6 +531,7 @@ cmd="${1:-help}"
 if [ "$#" -ge 1 ]; then shift; fi
 case "$cmd" in
     status)              cmd_status "$@" ;;
+    doctor)              cmd_doctor "$@" ;;
     start)               cmd_start "$@" ;;
     stop)                cmd_stop "$@" ;;
     restart)             cmd_restart "$@" ;;

--- a/test/zen/doctor.js
+++ b/test/zen/doctor.js
@@ -1,0 +1,95 @@
+import assert from "assert";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// `zen doctor` exists because nothing on a host errors when the installation
+// drifts away from the checkout. The auto-update timer here sat enabled,
+// active and dead for eight days without a log line, and every deploy in that
+// window silently needed a human. So what matters about this command is not
+// that it prints something when all is well -- it is that it says so, loudly
+// and with a non-zero exit, when it is not.
+const here = path.dirname(fileURLToPath(import.meta.url));
+const cli = path.join(here, "..", "..", "script", "zen.sh");
+
+function doctor(env) {
+  try {
+    return {
+      code: 0,
+      out: execFileSync("sh", [cli, "doctor"], {
+        env: { ...process.env, ...env },
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
+    };
+  } catch (e) {
+    return { code: e.status, out: (e.stdout || "") + (e.stderr || "") };
+  }
+}
+
+function sandbox(name) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "zen-doctor-" + name + "-"));
+  fs.mkdirSync(path.join(root, "cfg", "zen"), { recursive: true });
+  fs.mkdirSync(path.join(root, "install", "script"), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, "install", "package.json"),
+    JSON.stringify({ name: "@akaoio/zen", version: "0.0.0-test" }),
+  );
+  fs.writeFileSync(path.join(root, "cfg", "zen", "install_dir"), path.join(root, "install"));
+  fs.writeFileSync(path.join(root, "cfg", "zen", "service_name"), "zen-doctor-test");
+  return root;
+}
+
+describe("zen doctor", function () {
+  this.timeout(60 * 1000);
+
+  it("reports the installation it found", function () {
+    const root = sandbox("found");
+    const r = doctor({ XDG_CONFIG_HOME: path.join(root, "cfg") });
+    assert.ok(/ZEN doctor/.test(r.out), "no report at all:\n" + r.out);
+    assert.ok(
+      r.out.indexOf(path.join(root, "install")) >= 0,
+      "did not name the install it was pointed at:\n" + r.out,
+    );
+  });
+
+  it("says so, and fails, when the install is not a checkout", function () {
+    const root = sandbox("nogit");
+    const r = doctor({ XDG_CONFIG_HOME: path.join(root, "cfg") });
+    assert.ok(
+      /not a git checkout|no record of what was deployed/.test(r.out),
+      "a directory with no git and no deploy record passed unremarked:\n" + r.out,
+    );
+    assert.notStrictEqual(r.code, 0, "it found something wrong and still exited 0:\n" + r.out);
+  });
+
+  it("fails when it cannot find an installation at all", function () {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "zen-doctor-none-"));
+    fs.mkdirSync(path.join(root, "cfg", "zen"), { recursive: true });
+    // HOME too, or it finds the real one through the fallback path
+    const r = doctor({ XDG_CONFIG_HOME: path.join(root, "cfg"), HOME: root });
+    assert.notStrictEqual(r.code, 0, "no installation anywhere, and it exited 0:\n" + r.out);
+    assert.ok(/not found/.test(r.out), "did not say what was missing:\n" + r.out);
+  });
+
+  it("rejects an option it does not know instead of ignoring it", function () {
+    const root = sandbox("badopt");
+    let r;
+    try {
+      r = {
+        code: 0,
+        out: execFileSync("sh", [cli, "doctor", "--wat"], {
+          env: { ...process.env, XDG_CONFIG_HOME: path.join(root, "cfg") },
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "pipe"],
+        }),
+      };
+    } catch (e) {
+      r = { code: e.status, out: (e.stdout || "") + (e.stderr || "") };
+    }
+    assert.notStrictEqual(r.code, 0, "unknown option accepted silently");
+    assert.ok(/Unknown option/.test(r.out), "no word about the option:\n" + r.out);
+  });
+});


### PR DESCRIPTION
## Why

Nothing on a host errors when the installation stops matching the code it was installed from.

The auto-update timer on this relay sat **enabled, active and dead for eight days**. `systemctl status` said `active`. Not one log line was written. Every deploy in that window quietly needed a person to notice and run `zen update` by hand — and nobody did, because there was nothing to notice.

The same silence covers: a service still running from a directory an old install left behind, a relay several commits behind its own checkout, a store with keys that no longer read back, and a data directory that has run out of room.

## What

One command that asks those questions and prints the answer next to the fix.

```
$ zen doctor
ZEN doctor
────────────────────────────────
  ✓ install              /home/x/zen (v1.0.48)
  ✓ node                 v24.16.0 at /usr/bin/node
  ✓ service              zen active
  ✓ service points at    /home/x/zen
  ✓ deployed             67eda74 — the running service is this commit
  ✓ upstream             up to date
  ✓ auto-update          next Sun 2026-08-16 16:00:49 +07
  ✓ unit zen-update.service matches this checkout
  ✓ unit zen-update.timer matches this checkout
  ✓ disk                 259433MB free at /home/x/.local/share/zen/radata
────────────────────────────────
[info] Nothing to fix.
```

| | |
|---|---|
| `zen doctor` | the checks above; **non-zero exit** when anything needs attention, so it can be a health check rather than something to read |
| `zen doctor --fix` | rewrite the auto-update units from this checkout, restart the timer, then verify it really is scheduled |
| `zen doctor --deep` | also read every key in the store back through radisk |

The dead-timer check is the one that started this: systemd reports the next firing on two clocks, and a timer with neither is enabled, active, and dead. That is the exact state this machine was in.

## What it deliberately does not do

**It does not touch `zen.service`.** install.sh builds that one inline from install-time options, and `ssl.sh` has since added HTTPS lines to it by hand. Rewriting it from a template would throw those away.

**`--fix` asks for sudo interactively; the updater never holds it.** Letting `zen-update.service` write `/etc` would mean an hourly job that pulls code from GitHub and runs `npm install` also has root. Whoever controls the repo, an account, or any dependency would control this box. Detection is automatic; applying stays with a person at the keyboard.

## Tests

`test/zen/doctor.js`, in `test:zen:unit`. They were checked the only way worth checking: doctor was deliberately broken to always exit 0, and the test that guards the exit code went red.

`npm test`: **824 passing, 0 failing**.

## Separately worth a look

`script/zen.service` is referenced by nothing — install.sh generates that unit inline and ignores the file. It reads like the source of the installed unit and is not, which is what sent me looking for drift that did not exist. Either delete it or have install.sh render it; I did not want to bundle that decision into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)