### PR TITLE
test: run the systemd and shell-CLI tests only where they mean something

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@akaoio/zen",
   "type": "module",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "description": "A realtime, decentralized, offline-first, graph data synchronization engine.",
   "main": "index.min.js",
   "browser": "zen.min.js",

--- a/test/zen/doctor.js
+++ b/test/zen/doctor.js
@@ -43,6 +43,13 @@ function sandbox(name) {
 }
 
 describe("zen doctor", function () {
+  // `zen doctor` reads systemd units and runs the POSIX shell CLI -- neither exists on macOS or Windows, where these assert
+  // things about a deployment that cannot happen. Linux is where they mean
+  // something; elsewhere they only made CI red.
+  if ("linux" !== process.platform) {
+    it.skip("only meaningful on linux", function () {});
+    return;
+  }
   this.timeout(60 * 1000);
 
   it("reports the installation it found", function () {

--- a/test/zen/install-service.js
+++ b/test/zen/install-service.js
@@ -55,6 +55,13 @@ function render(opts) {
 }
 
 describe("the systemd unit install.sh writes", function () {
+  // install.sh builds a systemd unit with a POSIX shell -- neither exists on macOS or Windows, where these assert
+  // things about a deployment that cannot happen. Linux is where they mean
+  // something; elsewhere they only made CI red.
+  if ("linux" !== process.platform) {
+    it.skip("only meaningful on linux", function () {});
+    return;
+  }
   this.timeout(30 * 1000);
 
   it("leaves no placeholder behind", function () {


### PR DESCRIPTION
## What is wrong

CI has been red on every commit since 1.0.48 — **and it is my doing**. The last green run was #72 on 15 August; the two suites I added the next day are what broke it.

| runner | result |
|---|---|
| ubuntu | passing |
| macos | **4 failing** |
| windows | **6 failing** |

```
AssertionError: a directory with no git and no deploy record passed unremarked   <- test/zen/doctor.js
AssertionError: wrong user                                                        <- test/zen/install-service.js
AssertionError: missing Environment=PORT=8420 from: …
AssertionError: sections out of order: …
```

`test/zen/doctor.js` runs the CLI through `sh` and reads `/etc/systemd/system`. `test/zen/install-service.js` sources `install.sh` and inspects the systemd unit it renders. Neither systemd nor a POSIX shell of that shape exists on macOS or Windows, so on those runners the tests assert things about a deployment that cannot happen there.

They were never meaningful off Linux. They were only red.

## What this does

Skips both suites unless `process.platform === "linux"`, with the reason written where the skip is. Nothing about the Linux behaviour changes — 9 passing locally, `npm test` **829 passing, 0 failing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)